### PR TITLE
Relax pydantic dependency requirement to 2.10

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 dependencies = [
     "eval-type-backport>=0.2; python_version < '3.11'",
     "httpx>=0.28.1",
-    "pydantic>=2.11.7",
+    "pydantic>=2.10",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ dependencies = [
 requires-dist = [
     { name = "eval-type-backport", marker = "python_full_version < '3.11'", specifier = ">=0.2" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pydantic", specifier = ">=2.10" },
 ]
 
 [[package]]


### PR DESCRIPTION
As discussed in #146, this PR lowers the version requirement for `pydantic` in the dependency from 2.11.7 to 2.10.