### PR TITLE
Correctly account for output audio tokens in calculation

### DIFF
--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -556,6 +556,7 @@ class ModelPrice:
         if uncached_text_input_tokens < 0:
             raise ValueError('Uncached text input tokens cannot be negative')
         input_price += calc_mtok_price(self.input_mtok, uncached_text_input_tokens)
+        input_price += calc_mtok_price(self.cache_write_mtok, usage.cache_write_tokens)
 
         cached_text_input_tokens = usage.cache_read_tokens or 0
         cached_text_input_tokens -= cache_audio_read_tokens
@@ -563,10 +564,13 @@ class ModelPrice:
         if cached_text_input_tokens < 0:
             raise ValueError('cache_audio_read_tokens cannot be greater than cache_read_tokens')
         input_price += calc_mtok_price(self.cache_read_mtok, cached_text_input_tokens)
-
-        input_price += calc_mtok_price(self.cache_write_mtok, usage.cache_write_tokens)
-        output_price += calc_mtok_price(self.output_mtok, usage.output_tokens)
         input_price += calc_mtok_price(self.cache_audio_read_mtok, usage.cache_audio_read_tokens)
+
+        text_output_tokens = usage.output_tokens or 0
+        text_output_tokens -= usage.output_audio_tokens or 0
+        if text_output_tokens < 0:
+            raise ValueError('output_audio_tokens cannot be greater than output_tokens')
+        output_price += calc_mtok_price(self.output_mtok, text_output_tokens)
         output_price += calc_mtok_price(self.output_audio_mtok, usage.output_audio_tokens)
 
         total_price = input_price + output_price

--- a/tests/test_extract_usage.py
+++ b/tests/test_extract_usage.py
@@ -92,14 +92,14 @@ def test_openai():
             'prompt_tokens': 100,
             'completion_tokens': 200,
             'prompt_tokens_details': {'cached_tokens': None},
-            'completion_tokens_details': {'audio_tokens': 50},
+            'completion_tokens_details': None,
         },
     }
     usage = provider.extract_usage(response_data, api_flavor='chat')
-    assert usage == snapshot(('gpt-4.1', Usage(input_tokens=100, output_tokens=200, output_audio_tokens=50)))
+    assert usage == snapshot(('gpt-4.1', Usage(input_tokens=100, output_tokens=200)))
 
     extracted_usage = extract_usage(response_data, provider_id='openai', api_flavor='chat')
-    assert extracted_usage.usage == snapshot(Usage(input_tokens=100, output_tokens=200, output_audio_tokens=50))
+    assert extracted_usage.usage == snapshot(Usage(input_tokens=100, output_tokens=200))
     assert extracted_usage.provider.name == snapshot('OpenAI')
     assert extracted_usage.model.name == snapshot('gpt 4.1')
 

--- a/tests/test_price_calc.py
+++ b/tests/test_price_calc.py
@@ -256,3 +256,30 @@ def test_complex_usage():
         + Decimal('0.25') * cached_audio_tokens / mil
         + Decimal('1.0') * uncached_audio_tokens / mil
     )
+
+
+def test_output_audio_usage():
+    mil = 1_000_000
+
+    assert calc_price(
+        Usage(output_tokens=mil),
+        'gpt-4o-realtime-preview',
+    ).total_price == snapshot(Decimal('20.0'))
+
+    # All audio tokens
+    assert calc_price(
+        Usage(output_tokens=mil, output_audio_tokens=mil),
+        'gpt-4o-realtime-preview',
+    ).total_price == snapshot(Decimal('80.0'))
+
+    output_text_tokens = mil
+    output_audio_tokens = mil * 1000
+    total_output_tokens = output_text_tokens + output_audio_tokens
+    assert (
+        calc_price(
+            Usage(output_tokens=total_output_tokens, output_audio_tokens=output_audio_tokens),
+            'gpt-4o-realtime-preview',
+        ).total_price
+        == snapshot(Decimal('80020.0'))
+        == Decimal('20') * output_text_tokens / mil + Decimal('80') * output_audio_tokens / mil
+    )


### PR DESCRIPTION
Similar to how we account for cached and audio input tokens, output audio tokens are a subset of all output tokens.