### PR TITLE
Support failure mode for updatePrices factory

### DIFF
--- a/packages/js/src/api.ts
+++ b/packages/js/src/api.ts
@@ -1,4 +1,12 @@
-import type { PriceCalculationResult, PriceOptions, Provider, ProviderFindOptions, StorageFactoryParams, Usage } from './types'
+import type {
+  PriceCalculationResult,
+  PriceOptions,
+  Provider,
+  ProviderDataPayload,
+  ProviderFindOptions,
+  StorageFactoryParams,
+  Usage,
+} from './types'
 
 import { data as embeddedData } from './data'
 import { calcPrice as calcPriceInternal, getActiveModelPrice, matchModel, matchProvider } from './engine'
@@ -9,7 +17,8 @@ let providerData: Provider[] = embeddedData
 let providerDataPromise: Promise<null | Provider[]> = Promise.resolve(embeddedData)
 let autoUpdateCb: (() => void) | null = null
 
-function setProviderData(data: null | Promise<null | Provider[]> | Provider[]) {
+function setProviderData(data: ProviderDataPayload) {
+  // null means the update failed; keep existing data
   if (data === null) {
     return
   }

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -128,10 +128,13 @@ export interface PriceDataStorage {
   set: (data: string) => Promise<void>
 }
 
+type OptionalProviders = null | Provider[]
+export type ProviderDataPayload = OptionalProviders | Promise<OptionalProviders>
+
 export interface StorageFactoryParams {
   onCalc: (cb: () => void) => void
   remoteDataUrl: string
-  setProviderData: (data: Promise<Provider[]> | Provider[]) => void
+  setProviderData: (data: ProviderDataPayload) => void
 }
 
 export interface ProviderFindOptions {


### PR DESCRIPTION
Now, the logic can return null in case the update failed. Doing so keeps the current data.

Related to https://github.com/pydantic/pydantic-ai-gateway/pull/132. 