### PR TITLE
fix: broken link to openrouter in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Otherwise, to contribute:
 This project would not be possible without the following existing data sources:
 
 - [Helicone](https://github.com/Helicone/helicone/tree/main/packages/cost)
-- [Open Router](https://openrouter.ai/docs/api-reference/list-available-models)
+- [Open Router](https://openrouter.ai/docs/api/api-reference/models/get-models)
 - [LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json)
 - Simon Willison's [llm-prices](https://github.com/simonw/llm-prices/pull/7)
 

--- a/prices/README.md
+++ b/prices/README.md
@@ -35,7 +35,7 @@ Please do not:
 
 This project supports pulling prices from
 [Helicone](https://github.com/Helicone/helicone/tree/main/packages/cost),
-[Open Router](https://openrouter.ai/docs/api-reference/list-available-models),
+[Open Router](https://openrouter.ai/docs/api/api-reference/models/get-models),
 [LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) and
 Simon Willison's [llm-prices](https://github.com/simonw/llm-prices/pull/7)
 


### PR DESCRIPTION
## Summary
- Updated the OpenRouter API documentation link in both README files from the outdated URL to the current correct URL
- Old: `https://openrouter.ai/docs/api-reference/list-available-models`
- New: `https://openrouter.ai/docs/api/api-reference/models/get-models`

## Files Changed
- `README.md` - Updated link in the Thanks section
- `prices/README.md` - Updated link in the Automatic price discrepancy detection section