### PR TITLE
added auto-update command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ get-update-price-discrepancies: get-all-prices update-price-discrepancies ## get
 check-for-price-discrepancies: ## check for price discrepancies
 	uv run -m prices check_for_price_discrepancies
 
+.PHONY: auto-update
+auto-update: ## Run non-interactive auto-update of price aliases
+	uv run -m prices auto_update
+
 .PHONY: inject-providers
 inject-providers: ## inject providers into README.md
 	uv run -m prices inject_providers

--- a/prices/src/prices/__main__.py
+++ b/prices/src/prices/__main__.py
@@ -1,6 +1,7 @@
 import sys
 from inspect import getdoc
 
+from .auto_update import auto_update
 from .build import build
 from .collapse import collapse
 from .inject_providers import inject_providers
@@ -25,6 +26,7 @@ def main():
         get_simonw_prices,
         update_price_discrepancies,
         check_for_price_discrepancies,
+        auto_update,
         package_data,
         inject_providers,
     )

--- a/prices/src/prices/auto_update.py
+++ b/prices/src/prices/auto_update.py
@@ -1,0 +1,396 @@
+"""Non-interactive auto-update of price aliases.
+
+Detects missing model IDs from external price sources, classifies them as
+either auto-resolvable aliases (Tier 1) or models needing human review (Tier 2),
+and applies Tier 1 changes to the provider YAML files.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .price_discrepancies import can_ignore_missing_model, prices_conflict
+from .prices_types import ModelInfo, ModelPrice, TieredPrices
+from .source_prices import load_source_prices
+from .update import ProviderYaml, get_providers_yaml
+
+
+def is_name_prefix_match(existing_id: str, new_id: str) -> bool:
+    """Check if new_id is a variant of existing_id at a natural name boundary.
+
+    Two strategies:
+    1. Direct prefix: ``existing_id`` is a prefix of ``new_id`` and the remainder
+       starts with ``-``, ``.``, or ``:``.
+    2. Dot-dash equivalence: normalise ``\\d.\\d`` → ``\\d-\\d`` in both IDs, then
+       apply the same prefix-at-boundary check.
+
+    This intentionally prevents ``gpt-4`` from matching ``gpt-4o`` (remainder
+    must start with a separator, not an alphanumeric character).
+    """
+    if existing_id == new_id:
+        return False
+
+    def _is_prefix_at_boundary(prefix: str, full: str) -> bool:
+        if not full.startswith(prefix):
+            return False
+        remainder = full[len(prefix) :]
+        return bool(remainder) and remainder[0] in ('-', '.', ':')
+
+    # Strategy 1: direct prefix
+    if _is_prefix_at_boundary(existing_id, new_id):
+        return True
+
+    # Strategy 2: dot-dash equivalence (version numbers only)
+    def _normalize(s: str) -> str:
+        return re.sub(r'(\d)\.(\d)', r'\1-\2', s)
+
+    norm_existing = _normalize(existing_id)
+    norm_new = _normalize(new_id)
+    if norm_existing == existing_id and norm_new == new_id:
+        # No version-number dots to normalize — no match via this strategy
+        return False
+
+    return _is_prefix_at_boundary(norm_existing, norm_new)
+
+
+def get_dot_dash_variants(model_id: str) -> list[str]:
+    """Generate dot/dash variant for version-number segments.
+
+    For IDs containing ``\\d.\\d`` segments, returns the dash variant and vice-versa.
+    Only operates on version-like patterns (single digit around the separator).
+
+    Returns an empty list if no variant applies.
+    """
+    variants: list[str] = []
+
+    # dot → dash
+    dot_to_dash = re.sub(r'(\d)\.(\d)', r'\1-\2', model_id)
+    if dot_to_dash != model_id:
+        variants.append(dot_to_dash)
+
+    # dash → dot (only for version-like segments: single-digit around dash)
+    dash_to_dot = re.sub(r'(\d)-(\d)', r'\1.\2', model_id)
+    if dash_to_dot != model_id and dash_to_dot not in variants:
+        variants.append(dash_to_dot)
+
+    return variants
+
+
+@dataclass
+class AliasResolution:
+    """A model alias that can be automatically applied."""
+
+    provider_id: str
+    existing_model_id: str
+    new_alias: str
+    source_names: list[str]
+    price: dict[str, Any]
+    match_type: str = 'exact'  # 'exact' or 'subset'
+
+
+@dataclass
+class UnresolvedModel:
+    """A missing model that needs human review."""
+
+    provider_id: str
+    model_id: str
+    source_names: list[str]
+    price: dict[str, Any]
+    reason: str
+    candidate_model_ids: list[str]
+
+
+@dataclass
+class AutoUpdateReport:
+    """Result of an auto-update run."""
+
+    applied: list[AliasResolution] = field(default_factory=list)
+    unresolved: list[UnresolvedModel] = field(default_factory=list)
+    providers_saved: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _is_subset_price_match(existing: ModelPrice, source: ModelPrice) -> bool:
+    """Check if source price is a subset of existing price.
+
+    Returns True when every non-None field in ``source`` matches the
+    corresponding field in ``existing``. ``existing`` is allowed to have
+    extra fields that ``source`` doesn't report (e.g. ``cache_read_mtok``).
+
+    At least ``input_mtok`` or ``output_mtok`` must be present in source
+    to avoid matching on trivially sparse prices.
+    """
+    if source.input_mtok is None and source.output_mtok is None:
+        return False
+
+    for field_name in source.__pydantic_fields__:
+        source_val = getattr(source, field_name)
+        if source_val is None:
+            continue
+        existing_val = getattr(existing, field_name)
+        if existing_val is None:
+            return False
+        # Handle TieredPrices: compare base price
+        if isinstance(existing_val, TieredPrices):
+            if existing_val.base != source_val:
+                return False
+        elif existing_val != source_val:
+            return False
+    return True
+
+
+def classify_missing_model(
+    model_id: str,
+    price: ModelPrice,
+    provider_yml: ProviderYaml,
+    source_names: list[str],
+) -> AliasResolution | UnresolvedModel:
+    """Classify a missing model as auto-alias or needing human review."""
+    provider_id = provider_yml.provider.id
+    price_dict = price.model_dump(exclude_none=True, mode='json')
+
+    # Find all existing models with an exact price match
+    exact_matches: list[ModelInfo] = [
+        m for m in provider_yml.provider.models if isinstance(m.prices, ModelPrice) and m.prices == price
+    ]
+    match_type = 'exact'
+
+    # Fall back to subset match: source price has fewer fields but all present fields match
+    if not exact_matches:
+        exact_matches = [
+            m
+            for m in provider_yml.provider.models
+            if isinstance(m.prices, ModelPrice) and _is_subset_price_match(m.prices, price)
+        ]
+        match_type = 'subset'
+
+    if not exact_matches:
+        # Check for non-conflicting matches (for reason detail)
+        non_conflict = [
+            m
+            for m in provider_yml.provider.models
+            if isinstance(m.prices, ModelPrice)
+            and (not prices_conflict(m.prices, price) or not prices_conflict(price, m.prices))
+        ]
+        return UnresolvedModel(
+            provider_id=provider_id,
+            model_id=model_id,
+            source_names=source_names,
+            price=price_dict,
+            reason='no_exact_price_match',
+            candidate_model_ids=[m.id for m in non_conflict],
+        )
+
+    # Narrow by name prefix
+    name_matches = [m for m in exact_matches if is_name_prefix_match(m.id, model_id)]
+
+    if len(name_matches) == 1:
+        return AliasResolution(
+            provider_id=provider_id,
+            existing_model_id=name_matches[0].id,
+            new_alias=model_id,
+            source_names=source_names,
+            price=price_dict,
+            match_type=match_type,
+        )
+
+    if len(name_matches) > 1:
+        # Multiple name matches — pick the most specific (longest prefix).
+        # e.g. gpt-5 and gpt-5.1 both match gpt-5.1-chat, but gpt-5.1 is more specific.
+        name_matches.sort(key=lambda m: len(m.id), reverse=True)
+        if len(name_matches[0].id) > len(name_matches[1].id):
+            # Clear winner by length
+            return AliasResolution(
+                provider_id=provider_id,
+                existing_model_id=name_matches[0].id,
+                new_alias=model_id,
+                source_names=source_names,
+                price=price_dict,
+                match_type=match_type,
+            )
+        return UnresolvedModel(
+            provider_id=provider_id,
+            model_id=model_id,
+            source_names=source_names,
+            price=price_dict,
+            reason='multiple_exact_price_matches',
+            candidate_model_ids=[m.id for m in name_matches],
+        )
+
+    # Exact price match(es) but no name similarity — don't list all price-coincidence
+    # matches as candidates since they're misleading (many models share the same price).
+    return UnresolvedModel(
+        provider_id=provider_id,
+        model_id=model_id,
+        source_names=source_names,
+        price=price_dict,
+        reason='exact_price_match_but_no_name_similarity',
+        candidate_model_ids=[],
+    )
+
+
+_BEDROCK_VENDOR_PREFIXES = (
+    'anthropic.',
+    'amazon.',
+    'meta.',
+    'cohere.',
+    'ai21.',
+    'mistral.',
+    'writer.',
+    'deepseek.',
+    'openai.',
+    'google.',
+    'qwen.',
+    'minimax.',
+    'moonshot.',
+    'nvidia.',
+    'twelvelabs.',
+)
+
+_BEDROCK_REGION_PREFIXES = ('us.', 'eu.', 'apac.', 'global.')
+
+
+def _is_routing_path(model_id: str) -> bool:
+    """Check if a model ID is a routing path rather than a real model name.
+
+    Filters out:
+    - Slash-separated routing keys from LiteLLM (e.g. ``openrouter/meta-llama/llama-3-70b``,
+      ``anthropic/fast/claude-opus-4-6``)
+    - AWS Bedrock ARN-style IDs (e.g. ``anthropic.claude-3-5-haiku-20241022-v1:0``,
+      ``us.anthropic.claude-opus-4-6-v1``)
+    """
+    if '/' in model_id:
+        return True
+
+    # Strip regional prefix first (e.g. "us.anthropic.claude-..." → "anthropic.claude-...")
+    stripped = model_id
+    for rp in _BEDROCK_REGION_PREFIXES:
+        if stripped.startswith(rp):
+            stripped = stripped[len(rp) :]
+            break
+
+    # Check for Bedrock vendor-prefixed model IDs
+    if stripped.startswith(_BEDROCK_VENDOR_PREFIXES):
+        return True
+
+    return False
+
+
+def _collect_missing_models(
+    providers_yml: dict[str, ProviderYaml],
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """Collect missing models across all sources and providers.
+
+    Returns ``{provider_id: {model_id: [{'price': ModelPrice, 'sources': [str]}]}}``
+    """
+    source_prices = load_source_prices()
+    all_missing: dict[str, dict[str, list[dict[str, Any]]]] = {}
+
+    for provider_yml in providers_yml.values():
+        missing: dict[str, list[dict[str, Any]]] = {}
+        provider_id = provider_yml.provider.id
+
+        for source, sp in source_prices.items():
+            if provider_prices := sp.get(provider_id):
+                for model_id, price in provider_prices.items():
+                    if provider_id == 'groq':
+                        model_id = model_id.removeprefix('groq/')
+
+                    # Skip routing paths (e.g. "openrouter/meta-llama/...", "anthropic/fast/...")
+                    if _is_routing_path(model_id):
+                        continue
+
+                    if provider_yml.provider.find_model(model_id):
+                        continue
+
+                    entries = missing.setdefault(model_id, [])
+                    for other in entries:
+                        if not prices_conflict(price, other['price']) or not prices_conflict(other['price'], price):
+                            other['sources'].append(source)
+                            break
+                    else:
+                        entries.append(dict(price=price, sources=[source]))
+
+        if missing:
+            all_missing[provider_id] = missing
+
+    return all_missing
+
+
+def detect_auto_updates() -> AutoUpdateReport:
+    """Detect missing models and classify them. Does not modify any files."""
+    providers_yml = get_providers_yaml()
+    all_missing = _collect_missing_models(providers_yml)
+    report = AutoUpdateReport()
+
+    for provider_id, missing in all_missing.items():
+        provider_yml = providers_yml[provider_id]
+
+        for model_id, entries in missing.items():
+            if can_ignore_missing_model(provider_id, model_id):
+                continue
+
+            if len(entries) != 1:
+                price_dict = entries[0]['price'].model_dump(exclude_none=True, mode='json')
+                all_sources = [s for e in entries for s in e['sources']]
+                report.unresolved.append(
+                    UnresolvedModel(
+                        provider_id=provider_id,
+                        model_id=model_id,
+                        source_names=all_sources,
+                        price=price_dict,
+                        reason='conflicting_prices_across_sources',
+                        candidate_model_ids=[],
+                    ),
+                )
+                continue
+
+            entry = entries[0]
+            price: ModelPrice = entry['price']
+            source_names: list[str] = entry['sources']
+
+            result = classify_missing_model(model_id, price, provider_yml, source_names)
+
+            if isinstance(result, UnresolvedModel):
+                report.unresolved.append(result)
+            else:
+                report.applied.append(result)
+
+    return report
+
+
+def apply_auto_updates(report: AutoUpdateReport) -> list[str]:
+    """Apply aliases from a report to provider YAMLs. Returns list of saved provider IDs."""
+    providers_yml = get_providers_yaml()
+    modified_providers: set[str] = set()
+
+    for r in report.applied:
+        provider_yml = providers_yml[r.provider_id]
+        if not provider_yml.provider.find_model(r.new_alias):
+            provider_yml.add_id_to_model(r.existing_model_id, r.new_alias)
+            modified_providers.add(r.provider_id)
+
+        for variant in get_dot_dash_variants(r.new_alias):
+            if not provider_yml.provider.find_model(variant):
+                provider_yml.add_id_to_model(r.existing_model_id, variant)
+
+    saved: list[str] = []
+    for pid in modified_providers:
+        providers_yml[pid].save()
+        saved.append(pid)
+
+    return saved
+
+
+def auto_update() -> None:
+    """Detect new price aliases. Outputs JSON report to stdout."""
+    report = detect_auto_updates()
+    json.dump(report.to_dict(), sys.stdout, indent=2)
+    print(file=sys.stderr)
+    print(f'found {len(report.applied)} alias(es), {len(report.unresolved)} unresolved.', file=sys.stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,10 @@ quote-style = "single"
 [tool.pytest.ini_options]
 testpaths = "tests"
 xfail_strict = true
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    "ignore:`FieldValidationInfo` is deprecated:DeprecationWarning:pydantic_core",
+]
 markers = [
     "requires_latest_pydantic: marks tests that require Pydantic >2.10 for schema generation",
 ]

--- a/scripts/auto-update.sh
+++ b/scripts/auto-update.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Fetch latest prices, detect aliases, apply, build, and optionally open a PR.
+#
+# Usage:
+#   ./auto-update.sh           # fetch, detect, apply, format, build — review the diff
+#   ./auto-update.sh --pr      # same, then commit, push, and open a PR
+#
+
+set -e
+
+# ── Refuse to run on a dirty tree ────────────────────────────────────
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Error: working tree has uncommitted changes. Commit or stash them first."
+  exit 1
+fi
+
+# ── Full pipeline: fetch, detect, apply, format, build ───────────────
+REPORT_JSON=$(mktemp)
+PR_BODY=$(mktemp)
+trap 'rm -f "$REPORT_JSON" "$PR_BODY"' EXIT
+
+echo "==> Fetching source prices..."
+uv run -m prices get_openrouter_prices
+uv run -m prices get_litellm_prices
+uv run -m prices get_simonw_prices
+
+echo "==> Detecting and applying aliases..."
+uv run python -c "
+import json
+from prices.auto_update import detect_auto_updates, apply_auto_updates
+report = detect_auto_updates()
+with open('$REPORT_JSON', 'w') as f:
+    json.dump(report.to_dict(), f, indent=2)
+if not report.applied:
+    print('No aliases to apply.')
+    raise SystemExit(0)
+print(f'Found {len(report.applied)} alias(es), applying...')
+saved = apply_auto_updates(report)
+print(f'Applied to {len(saved)} provider(s).')
+"
+
+# Exit early if nothing was applied
+n_applied=$(jq '.applied | length' "$REPORT_JSON")
+if [ "$n_applied" -eq 0 ]; then
+  echo "Nothing to do."
+  exit 0
+fi
+
+# ── Generate PR body markdown from report JSON ────────────────────────
+echo "==> Generating PR body..."
+{
+  echo "## Auto-Update Price Aliases"
+  echo ""
+  echo "### Auto-Applied Aliases"
+  echo ""
+  echo "| Provider | New Alias | Mapped To | Price Match | Name Prefix | Sources |"
+  echo "|----------|-----------|-----------|:-----------:|:-----------:|---------|"
+  jq -r '.applied[] | "| \(.provider_id) | `\(.new_alias)` | `\(.existing_model_id)` | \(.match_type) | yes | \(.source_names | join(", ")) |"' "$REPORT_JSON"
+
+  n_unresolved=$(jq '.unresolved | length' "$REPORT_JSON")
+  if [ "$n_unresolved" -gt 0 ]; then
+    echo ""
+    echo "### Unrecognized Models (require review)"
+    echo ""
+    jq -r '.unresolved | group_by(.provider_id) | .[] | "**\(.[0].provider_id)**\n\([ .[] | "- `\(.model_id)` (\(.source_names | join(", ")))" ] | join("\n"))\n"' "$REPORT_JSON"
+  fi
+} > "$PR_BODY"
+
+# ── Format + build (mirrors pre-commit hooks so commit is clean) ─────
+echo "==> Formatting and building..."
+uv run ruff format
+uv run ruff check --fix --fix-only
+uv sync --frozen --all-packages --all-extras
+npm install
+make collapse-models
+make build
+uv run -m prices inject_providers
+npx prettier --write --ignore-unknown prices/providers/ packages/
+
+if [ "$1" != "--pr" ]; then
+  echo "Done."
+  exit 0
+fi
+
+# ── Commit, push, and open PR ────────────────────────────────────────
+echo "==> Creating PR..."
+git checkout -B auto-update/prices main
+git add prices/providers/ prices/data.json prices/data_slim.json packages/
+git add prices/data.schema.json prices/data_slim.schema.json
+git commit -m "feat: auto-update price aliases"
+git push -u origin auto-update/prices --force-with-lease
+gh pr create \
+  --title "feat: auto-update price aliases" \
+  --body-file "$PR_BODY"

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -1,0 +1,329 @@
+"""Tests for the auto_update module."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from prices.auto_update import (
+    AliasResolution,
+    AutoUpdateReport,
+    UnresolvedModel,
+    _is_routing_path,
+    _is_subset_price_match,
+    classify_missing_model,
+    get_dot_dash_variants,
+    is_name_prefix_match,
+)
+from prices.prices_types import ClauseEquals, ModelInfo, ModelPrice
+
+# ── _is_routing_path ──────────────────────────────────────────────────
+
+
+class TestIsRoutingPath:
+    def test_slash_separated(self):
+        assert _is_routing_path('openrouter/meta-llama/llama-3-70b') is True
+
+    def test_litellm_routing(self):
+        assert _is_routing_path('anthropic/fast/claude-opus-4-6') is True
+
+    def test_bedrock_vendor_prefix(self):
+        assert _is_routing_path('anthropic.claude-3-5-haiku-20241022-v1:0') is True
+
+    def test_bedrock_regional_prefix(self):
+        assert _is_routing_path('us.anthropic.claude-opus-4-6-v1') is True
+
+    def test_bedrock_eu_prefix(self):
+        assert _is_routing_path('eu.amazon.nova-2-lite-v1:0') is True
+
+    def test_bedrock_apac_prefix(self):
+        assert _is_routing_path('apac.anthropic.claude-opus-4-6-v1') is True
+
+    def test_bedrock_global_prefix(self):
+        assert _is_routing_path('global.anthropic.claude-opus-4-6-v1') is True
+
+    def test_normal_model_id(self):
+        assert _is_routing_path('gpt-5.2-chat-latest') is False
+
+    def test_model_with_colon(self):
+        assert _is_routing_path('claude-3:thinking') is False
+
+    def test_model_with_version_dot(self):
+        assert _is_routing_path('gpt-4.1-mini') is False
+
+
+# ── _is_subset_price_match ────────────────────────────────────────────
+
+
+class TestIsSubsetPriceMatch:
+    def test_exact_match_is_subset(self):
+        existing = ModelPrice(
+            input_mtok=Decimal('1.25'),
+            cache_read_mtok=Decimal('0.125'),
+            output_mtok=Decimal(10),
+        )
+        source = ModelPrice(
+            input_mtok=Decimal('1.25'),
+            cache_read_mtok=Decimal('0.125'),
+            output_mtok=Decimal(10),
+        )
+        assert _is_subset_price_match(existing, source) is True
+
+    def test_source_missing_cache_read(self):
+        """Source omits cache_read_mtok but input/output match."""
+        existing = ModelPrice(
+            input_mtok=Decimal('1.75'),
+            cache_read_mtok=Decimal('0.175'),
+            output_mtok=Decimal(14),
+        )
+        source = ModelPrice(input_mtok=Decimal('1.75'), output_mtok=Decimal(14))
+        assert _is_subset_price_match(existing, source) is True
+
+    def test_source_has_different_value(self):
+        existing = ModelPrice(input_mtok=Decimal('1.75'), output_mtok=Decimal(14))
+        source = ModelPrice(input_mtok=Decimal('1.75'), output_mtok=Decimal(99))
+        assert _is_subset_price_match(existing, source) is False
+
+    def test_source_has_field_existing_lacks(self):
+        """Source reports cache_read but existing doesn't have it."""
+        existing = ModelPrice(input_mtok=Decimal('1.75'), output_mtok=Decimal(14))
+        source = ModelPrice(
+            input_mtok=Decimal('1.75'),
+            cache_read_mtok=Decimal('0.5'),
+            output_mtok=Decimal(14),
+        )
+        assert _is_subset_price_match(existing, source) is False
+
+    def test_trivial_source_rejected(self):
+        """Source with no input or output is too sparse."""
+        existing = ModelPrice(input_mtok=Decimal(1), output_mtok=Decimal(2))
+        source = ModelPrice(requests_kcount=Decimal('0.5'))
+        assert _is_subset_price_match(existing, source) is False
+
+
+# ── is_name_prefix_match ──────────────────────────────────────────────
+
+
+class TestIsNamePrefixMatch:
+    def test_direct_prefix_dash(self):
+        assert is_name_prefix_match('gpt-5.2', 'gpt-5.2-chat-latest') is True
+
+    def test_direct_prefix_dot(self):
+        assert is_name_prefix_match('gpt-4.1', 'gpt-4.1-mini-2025-04-14') is True
+
+    def test_direct_prefix_colon(self):
+        assert is_name_prefix_match('claude-3', 'claude-3:thinking') is True
+
+    def test_dot_dash_equivalence(self):
+        """gpt-5.2 should match gpt-5-2-chat-latest via normalization."""
+        assert is_name_prefix_match('gpt-5.2', 'gpt-5-2-chat-latest') is True
+
+    def test_dot_dash_equivalence_reverse(self):
+        """gpt-5-2 (dash form) should match gpt-5.2-chat-latest (dot form)."""
+        assert is_name_prefix_match('gpt-5-2', 'gpt-5.2-chat-latest') is True
+
+    def test_boundary_safety_no_separator(self):
+        """gpt-4 must NOT match gpt-4o (remainder starts with 'o', not a separator)."""
+        assert is_name_prefix_match('gpt-4', 'gpt-4o') is False
+
+    def test_boundary_safety_alphanumeric(self):
+        assert is_name_prefix_match('gpt-4', 'gpt-4omni') is False
+
+    def test_completely_different_names(self):
+        assert is_name_prefix_match('claude-3', 'gpt-4-turbo') is False
+
+    def test_same_id(self):
+        assert is_name_prefix_match('gpt-4o', 'gpt-4o') is False
+
+    def test_no_version_dot_no_match(self):
+        """Without version-number dots, dot-dash equivalence doesn't apply."""
+        assert is_name_prefix_match('claude-sonnet', 'claude.sonnet-v2') is False
+
+    def test_existing_longer_than_new(self):
+        assert is_name_prefix_match('gpt-5.2-chat-latest', 'gpt-5.2') is False
+
+
+# ── get_dot_dash_variants ─────────────────────────────────────────────
+
+
+class TestGetDotDashVariants:
+    def test_dot_to_dash(self):
+        variants = get_dot_dash_variants('gpt-5.2-chat')
+        assert 'gpt-5-2-chat' in variants
+
+    def test_dash_to_dot(self):
+        variants = get_dot_dash_variants('gpt-5-2-chat')
+        assert 'gpt-5.2-chat' in variants
+
+    def test_no_version_segments(self):
+        assert get_dot_dash_variants('claude-sonnet-latest') == []
+
+    def test_multiple_version_segments(self):
+        variants = get_dot_dash_variants('model-1.2-v3.4')
+        assert 'model-1-2-v3-4' in variants
+
+    def test_no_op_for_long_numbers(self):
+        """multi-digit numbers around separator aren't version-like enough for dash→dot."""
+        # 12-34 would match \d-\d but that's fine; the regex matches single digits around the sep
+        variants = get_dot_dash_variants('model-v12.3')
+        # 12.3 → 12-3 matches (\d)\.(\d) at "2.3"
+        assert 'model-v12-3' in variants
+
+
+# ── classify_missing_model ────────────────────────────────────────────
+
+
+def _make_provider_yml(models: list[ModelInfo]) -> MagicMock:
+    """Create a mock ProviderYaml with the given models."""
+    mock = MagicMock()
+    mock.provider.id = 'openai'
+    mock.provider.models = models
+    mock.find_model.return_value = None
+    return mock
+
+
+def _make_model(
+    model_id: str,
+    input_mtok: Decimal = Decimal('2.5'),
+    output_mtok: Decimal = Decimal(10),
+) -> ModelInfo:
+    return ModelInfo(
+        id=model_id,
+        prices=ModelPrice(input_mtok=input_mtok, output_mtok=output_mtok),
+        match=ClauseEquals(equals=model_id),
+    )
+
+
+class TestClassifyMissingModel:
+    def test_exact_price_and_prefix_match_is_tier1(self):
+        """Exact price + name prefix → Tier 1 alias."""
+        existing = _make_model('gpt-5.2', Decimal('2.5'), Decimal(10))
+        provider = _make_provider_yml([existing])
+        price = ModelPrice(input_mtok=Decimal('2.5'), output_mtok=Decimal(10))
+
+        result = classify_missing_model('gpt-5.2-chat-latest', price, provider, ['litellm'])
+
+        assert isinstance(result, AliasResolution)
+        assert result.existing_model_id == 'gpt-5.2'
+        assert result.new_alias == 'gpt-5.2-chat-latest'
+
+    def test_exact_price_no_name_similarity_is_tier2(self):
+        """Exact price but unrelated name → Tier 2."""
+        existing = _make_model('computer-use', Decimal(3), Decimal(15))
+        provider = _make_provider_yml([existing])
+        price = ModelPrice(input_mtok=Decimal(3), output_mtok=Decimal(15))
+
+        result = classify_missing_model('ft:gpt-4.1', price, provider, ['openrouter'])
+
+        assert isinstance(result, UnresolvedModel)
+        assert result.reason == 'exact_price_match_but_no_name_similarity'
+        assert result.candidate_model_ids == []  # price-coincidence candidates are noise
+
+    def test_subset_price_and_prefix_match_is_tier1(self):
+        """Source omits cache_read_mtok but input/output match + name prefix → Tier 1."""
+        existing = ModelInfo(
+            id='gpt-5.2',
+            prices=ModelPrice(
+                input_mtok=Decimal('1.75'),
+                cache_read_mtok=Decimal('0.175'),
+                output_mtok=Decimal(14),
+            ),
+            match=ClauseEquals(equals='gpt-5.2'),
+        )
+        provider = _make_provider_yml([existing])
+        # Source only reports input + output (no cache_read)
+        price = ModelPrice(input_mtok=Decimal('1.75'), output_mtok=Decimal(14))
+
+        result = classify_missing_model('gpt-5.2-chat-latest', price, provider, ['litellm'])
+
+        assert isinstance(result, AliasResolution)
+        assert result.existing_model_id == 'gpt-5.2'
+
+    def test_no_price_match_is_tier2(self):
+        """No existing model has matching price → Tier 2."""
+        existing = _make_model('gpt-5.2', Decimal('2.5'), Decimal(10))
+        provider = _make_provider_yml([existing])
+        price = ModelPrice(input_mtok=Decimal(99), output_mtok=Decimal(99))
+
+        result = classify_missing_model('gpt-5.2-chat', price, provider, ['litellm'])
+
+        assert isinstance(result, UnresolvedModel)
+        assert result.reason == 'no_exact_price_match'
+
+    def test_multiple_exact_matches_narrowed_by_name(self):
+        """Multiple exact matches, but only one passes name prefix → Tier 1."""
+        model_a = _make_model('gpt-5.2', Decimal('2.5'), Decimal(10))
+        model_b = _make_model('unrelated-model', Decimal('2.5'), Decimal(10))
+        provider = _make_provider_yml([model_a, model_b])
+        price = ModelPrice(input_mtok=Decimal('2.5'), output_mtok=Decimal(10))
+
+        result = classify_missing_model('gpt-5.2-chat-latest', price, provider, ['litellm'])
+
+        assert isinstance(result, AliasResolution)
+        assert result.existing_model_id == 'gpt-5.2'
+
+    def test_multiple_name_matches_picks_longest_prefix(self):
+        """Multiple name matches → pick the most specific (longest) prefix."""
+        model_a = _make_model('gpt-5.2', Decimal('2.5'), Decimal(10))
+        model_b = _make_model('gpt-5.2-turbo', Decimal('2.5'), Decimal(10))
+        provider = _make_provider_yml([model_a, model_b])
+        price = ModelPrice(input_mtok=Decimal('2.5'), output_mtok=Decimal(10))
+
+        # gpt-5.2-turbo-latest matches both gpt-5.2 and gpt-5.2-turbo as prefix,
+        # but gpt-5.2-turbo is more specific → Tier 1
+        result = classify_missing_model('gpt-5.2-turbo-latest', price, provider, ['litellm'])
+
+        assert isinstance(result, AliasResolution)
+        assert result.existing_model_id == 'gpt-5.2-turbo'
+
+    def test_multiple_name_matches_same_length_is_tier2(self):
+        """Multiple name matches with same-length prefixes → Tier 2."""
+        model_a = _make_model('gpt-5.2a', Decimal('2.5'), Decimal(10))
+        model_b = _make_model('gpt-5.2b', Decimal('2.5'), Decimal(10))
+        provider = _make_provider_yml([model_a, model_b])
+        price = ModelPrice(input_mtok=Decimal('2.5'), output_mtok=Decimal(10))
+
+        result = classify_missing_model('gpt-5.2a-latest', price, provider, ['litellm'])
+
+        # Only gpt-5.2a matches (gpt-5.2b doesn't prefix-match gpt-5.2a-latest)
+        assert isinstance(result, AliasResolution)
+        assert result.existing_model_id == 'gpt-5.2a'
+
+
+# ── AutoUpdateReport.to_dict ─────────────────────────────────────────
+
+
+class TestToDict:
+    def test_round_trips(self):
+        report = AutoUpdateReport(
+            applied=[
+                AliasResolution(
+                    provider_id='openai',
+                    existing_model_id='gpt-5.2',
+                    new_alias='gpt-5.2-chat-latest',
+                    source_names=['litellm', 'openrouter'],
+                    price={'input_mtok': '2.5'},
+                ),
+            ],
+            unresolved=[
+                UnresolvedModel(
+                    provider_id='openai',
+                    model_id='unknown',
+                    source_names=['openrouter'],
+                    price={'input_mtok': '99'},
+                    reason='no_exact_price_match',
+                    candidate_model_ids=[],
+                ),
+            ],
+        )
+        d = report.to_dict()
+        assert len(d['applied']) == 1
+        assert d['applied'][0]['new_alias'] == 'gpt-5.2-chat-latest'
+        assert d['applied'][0]['match_type'] == 'exact'
+        assert len(d['unresolved']) == 1
+        assert d['unresolved'][0]['model_id'] == 'unknown'
+
+    def test_empty_report(self):
+        d = AutoUpdateReport().to_dict()
+        assert d['applied'] == []
+        assert d['unresolved'] == []


### PR DESCRIPTION
## Summary

  - Add non-interactive auto-update system that detects missing model IDs from
  external price sources (OpenRouter, LiteLLM, Simon Willison), classifies them as
  auto-resolvable aliases or models needing human review, and applies safe changes to
   provider YAML files
  - Add `scripts/auto-update.sh` orchestrator script
  automate the full flow (fetch prices, detect, apply, format, build, open PR). This can be called by a auto-scheduled github action later (if desired)
  - Add 40 unit tests covering name matching, price matching, classification logic,
  and routing path filtering

  ## How it works

  When providers release new models (e.g. `gpt-5.2-chat-latest`), external sources
  pick up the new slug before this repo does. The auto-update system:

  1. **Detects** missing model IDs across all providers and sources
  2. **Classifies** each as auto-resolvable (exact/subset price match + name prefix
  match) or needing human review
  3. **Applies** safe aliases to provider YAMLs, including dot/dash variants
  (`gpt-5.2` ↔ `gpt-5-2`)
  4. **Filters** noise: LiteLLM routing paths (`openrouter/meta-llama/...`), Bedrock
  ARN-style IDs (`us.anthropic.claude-...`)

  The Python CLI (`uv run -m prices auto_update`) outputs a JSON report only — zero
  side effects. All file mutations, formatting, building, and PR creation are handled
   by the shell script.

### Github Action
Seperately to this PR, you can add a github action to execute this at a specific cadence .

Example:
```
name: Auto-Update Prices
on:
  schedule:
    - cron: "0 8 * * 1" # Weekly Monday 08:00 UTC
  workflow_dispatch: {} # Manual trigger

permissions:
  contents: write
  pull-requests: write

jobs:
  auto-update:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
        with:
          repository: atsaplin/genai-prices

      - uses: astral-sh/setup-uv@v6

      - run: uv sync --frozen --all-packages

      - name: Run auto-update and open PR
        run: ./scripts/auto-update.sh --pr
        env:
          GH_TOKEN: ${{ github.token }}

```

  ## Files

  | File | Description |
  |------|-------------|
  | `prices/src/prices/auto_update.py` | Core detection/classification/apply logic |
  | `prices/src/prices/__main__.py` | Register `auto_update` CLI command |
  | `scripts/auto-update.sh` | Orchestrator: fetch, detect, apply, format, build, PR
  |
  | `.github/workflows/auto-update-prices.yml` | Weekly scheduled Action (Monday
  08:00 UTC) |
  | `Makefile` | `auto-update` target |
  | `tests/test_auto_update.py` | 40 unit tests |

  ## Test plan

  - [x] `make test` — 379 tests pass (40 new + 339 existing)
  - [x] End-to-end local run: detects 8 aliases, applies to 5 providers
  - [x] No temp file artifacts left on disk (mktemp + trap cleanup)
  - [x] jq PR body generation renders clean markdown