### PR TITLE
Keep `_background_task` alive to update_prices after failed attempts

### DIFF
--- a/packages/python/genai_prices/update_prices.py
+++ b/packages/python/genai_prices/update_prices.py
@@ -99,8 +99,8 @@ class UpdatePrices:
             timeout: The maximum time to wait for the prices to be updated in seconds.
         """
         prices_updated = self._prices_updated.wait(timeout=timeout)
-        if self._background_exc:
-            exc = self._background_exc
+        exc = self._background_exc
+        if exc:
             self._background_exc = None
             raise exc
         return prices_updated

--- a/packages/python/genai_prices/update_prices.py
+++ b/packages/python/genai_prices/update_prices.py
@@ -5,6 +5,7 @@ import logging
 import threading
 from dataclasses import dataclass, field
 from time import time
+from typing import final
 
 import httpx
 
@@ -131,15 +132,17 @@ class UpdatePrices:
         logger.info('Starting genai-prices background task')
         try:
             while True:
-                self._update_prices()
-                self._prices_updated.set()
-                if self._stop_event.wait(self.update_interval):
+                try:
+                    self._update_prices()
+                    self._prices_updated.set()
+                except Exception as e:
+                    self._background_exc = e
+                    self._prices_updated.set()
+                    logger.error('Error updating genai-prices in the background (%s): %s', type(e).__name__, e)
+                if self._stop_event.wait(self.update_interval):  # Wait for an hour before retrying
                     break
-        except Exception as e:
-            self._background_exc = e
-            self._prices_updated.set()
-            logger.error('Error updating genai-prices in the background (%s): %s', type(e).__name__, e)
-        else:
+
+        finally:
             logger.info('genai-prices background task stopped')
 
     def _update_prices(self):

--- a/packages/python/genai_prices/update_prices.py
+++ b/packages/python/genai_prices/update_prices.py
@@ -134,11 +134,12 @@ class UpdatePrices:
                 try:
                     self._update_prices()
                     self._prices_updated.set()
+                    self._background_exc = None
                 except Exception as e:
                     self._background_exc = e
                     self._prices_updated.set()
                     logger.error('Error updating genai-prices in the background (%s): %s', type(e).__name__, e)
-                if self._stop_event.wait(self.update_interval):  # Wait for an hour before retrying
+                if self._stop_event.wait(self.update_interval):
                     break
 
         finally:

--- a/packages/python/genai_prices/update_prices.py
+++ b/packages/python/genai_prices/update_prices.py
@@ -5,7 +5,6 @@ import logging
 import threading
 from dataclasses import dataclass, field
 from time import time
-from typing import final
 
 import httpx
 


### PR DESCRIPTION
`background_task` would exit the loop if `_update_prices()` throws. Preventing that to keep the loop alive.