### PR TITLE
Prep 0.0.58 release

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/genai-prices",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "Calculate prices for calling LLM inference APIs",
   "author": "Pydantic Team",
   "type": "module",

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "genai-prices"
-version = "0.0.57"
+version = "0.0.58"
 description = "Calculate prices for calling LLM inference APIs."
 readme = "README.md"
 authors = [{ name = "Samuel Colvin", email = "samuel@pydantic.dev" }]

--- a/uv.lock
+++ b/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.57"
+version = "0.0.58"
 source = { editable = "packages/python" }
 dependencies = [
     { name = "eval-type-backport", marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Bump Python and JS package versions to 0.0.58 for the next release.