### PR TITLE
Fix compact dated LiteLLM model refs

### DIFF
--- a/packages/python/genai_prices/data_snapshot.py
+++ b/packages/python/genai_prices/data_snapshot.py
@@ -13,6 +13,8 @@ __all__ = 'DataSnapshot', 'set_custom_snapshot'
 # snapshot set by UpdatePrices, or manually by the user
 _custom_snapshot: DataSnapshot | None = None
 
+_COMPACT_DATE_MODEL_REF_RE = re.compile(r'(?P<prefix>.*-)(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})$')
+
 
 def get_snapshot() -> DataSnapshot:
     if _custom_snapshot is not None:
@@ -30,6 +32,10 @@ def _bundled_snapshot() -> DataSnapshot:
 def set_custom_snapshot(snapshot: DataSnapshot | None):
     global _custom_snapshot
     _custom_snapshot = snapshot
+
+
+def _normalize_compact_date_model_ref(model_ref: str) -> str:
+    return _COMPACT_DATE_MODEL_REF_RE.sub(r'\g<prefix>\g<year>-\g<month>-\g<day>', model_ref)
 
 
 @dataclass
@@ -109,8 +115,15 @@ class DataSnapshot:
         if model := provider.find_model(model_ref, all_providers=self.providers):
             self._lookup_cache[(provider_id, provider_api_url, model_ref)] = ret = provider, model
             return ret
-        else:
-            raise LookupError(f'Unable to find model with {model_ref=!r} in {provider.id}')
+
+        normalized_model_ref = _normalize_compact_date_model_ref(model_ref)
+        if normalized_model_ref != model_ref and (
+            model := provider.find_model(normalized_model_ref, all_providers=self.providers)
+        ):
+            self._lookup_cache[(provider_id, provider_api_url, model_ref)] = ret = provider, model
+            return ret
+
+        raise LookupError(f'Unable to find model with {model_ref=!r} in {provider.id}')
 
     def find_provider(
         self,

--- a/tests/test_model_matching.py
+++ b/tests/test_model_matching.py
@@ -609,6 +609,10 @@ def test_litellm_provider_id():
     assert provider.id == 'openai'
     assert model.id == 'gpt-4.1'
 
+    provider, model = snapshot.find_provider_model('openai/gpt-5.2-20251211', None, 'litellm', None)
+    assert provider.id == 'openai'
+    assert model.id == 'gpt-5.2'
+
     provider, model = snapshot.find_provider_model('anthropic/claude-3-5-sonnet-20241022', None, 'litellm', None)
     assert provider.id == 'anthropic'
     assert model.id == 'claude-3-5-sonnet'

--- a/tests/test_price_calc.py
+++ b/tests/test_price_calc.py
@@ -21,6 +21,13 @@ def test_sync_success_with_provider():
     assert price.auto_update_timestamp is None
 
 
+def test_litellm_compact_date_model_ref():
+    price = calc_price(Usage(input_tokens=1000, output_tokens=100), 'openai/gpt-5.2-20251211', provider_id='litellm')
+    expected_price = calc_price(Usage(input_tokens=1000, output_tokens=100), 'gpt-5.2-2025-12-11', provider_id='openai')
+
+    assert price == expected_price
+
+
 def test_sync_success_with_url():
     price = calc_price(
         Usage(input_tokens=1000, output_tokens=100, cache_write_tokens=20, cache_read_tokens=30),


### PR DESCRIPTION
Fixes #333

## Summary
- normalize trailing compact date model refs like gpt-5.2-20251211 as a fallback after exact model lookup fails
- keep the original cache key so repeated lookups of the original ref still benefit from caching
- cover both find_provider_model and the public calc_price path for LiteLLM-prefixed refs

## Tests
- UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --package genai-prices pytest tests/test_model_matching.py -k litellm_provider_id
- UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --package genai-prices pytest tests/test_price_calc.py -k compact_date_model_ref
- UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --package genai-prices ruff check packages/python/genai_prices/data_snapshot.py tests/test_model_matching.py tests/test_price_calc.py
- UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --package genai-prices ruff format --check packages/python/genai_prices/data_snapshot.py tests/test_model_matching.py tests/test_price_calc.py
- UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --package genai-prices basedpyright packages/python/genai_prices/data_snapshot.py tests/test_model_matching.py tests/test_price_calc.py