### PR TITLE
Handle missing fallback providers

### DIFF
--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -304,7 +304,7 @@ class Provider:
                 return model
         if self.fallback_model_providers and all_providers:
             for provider_id in self.fallback_model_providers:
-                provider = next(p for p in all_providers if p.id == provider_id)
+                provider = next((p for p in all_providers if p.id == provider_id), None)
                 if provider:
                     # don't pass all_providers when falling back, so we can only have one step of fallback
                     if model := provider.find_model(model_ref):

--- a/tests/test_model_matching.py
+++ b/tests/test_model_matching.py
@@ -494,6 +494,21 @@ def test_fallback_when_model_not_found_directly():
     assert non_existent is None
 
 
+def test_missing_fallback_provider_returns_none():
+    """Test that a missing fallback provider is ignored."""
+    from genai_prices.types import Provider
+
+    main_provider = Provider(
+        id='main-provider',
+        name='Main Provider',
+        api_pattern='main.example.com',
+        fallback_model_providers=['missing-provider'],
+        models=[],
+    )
+
+    assert main_provider.find_model('missing-model', all_providers=[main_provider]) is None
+
+
 def test_prioritize_direct_match_over_fallback():
     """Test that direct matches are prioritized over fallback matches."""
     from genai_prices.types import ClauseEquals, ModelInfo, ModelPrice, Provider


### PR DESCRIPTION
Fixes #265

## Summary
- make Provider.find_model ignore fallback provider IDs that are not present in all_providers
- preserve the existing one-step fallback behavior when the referenced provider exists
- add a regression test for a missing fallback provider returning None instead of raising StopIteration

## Tests
- UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --package genai-prices pytest tests/test_model_matching.py -k "fallback_provider or fallback_when_model_not_found_directly or chained_fallbacks_one_step"
- UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --package genai-prices ruff check packages/python/genai_prices/types.py tests/test_model_matching.py
- UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --package genai-prices ruff format --check packages/python/genai_prices/types.py tests/test_model_matching.py
- UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run --package genai-prices basedpyright packages/python/genai_prices/types.py tests/test_model_matching.py