### PR TITLE
Fix npm release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
+          registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
       - id: check-package-version
@@ -178,6 +179,5 @@ jobs:
           version_file_path: packages/js/package.json
           version_pattern: '"version": *"(?P<version>.+?)"'
 
-      - run: npm install -g npm@latest
-      - run: npm install
+      - run: npm ci
       - run: npm publish --workspace=packages/js


### PR DESCRIPTION
## Summary
- remove the release job's global npm self-upgrade
- use the setup-node npm registry configuration for trusted publishing
- install locked workspace dependencies with npm ci before publishing

## Why
The npm release job has been failing before project dependencies are installed:

```
Cannot find module 'promise-retry'
Require stack:
- .../node_modules/npm/node_modules/@npmcli/arborist/...
```

That failure happens while running `npm install -g npm@latest`, so the job is mutating the same global npm installation it is currently using. The release workflow already uses Node 24, whose bundled npm satisfies npm trusted publishing requirements, so the self-upgrade is unnecessary and makes the release path less deterministic.

This aligns the npm release job with npm's trusted publishing guidance: Node 24, explicit npm registry configuration, no package-manager cache in the release job, `npm ci`, then `npm publish`.

## Verification
- `npm ci`
- `npm run ci`
- `npm publish --workspace=packages/js --dry-run --cache /tmp/genai-prices-npm-cache`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `npm` release publishing by removing the self-upgrade and using trusted publishing settings. Installs locked deps with `npm ci` to make the job deterministic and avoid pre-publish module errors on Node 24.

- **Bug Fixes**
  - Remove global `npm install -g npm@latest`.
  - Configure `actions/setup-node` with `registry-url` for trusted publishing.
  - Replace `npm install` with `npm ci` before `npm publish`.

<sup>Written for commit 17c4a37e190b6dcbe5f303707240b975ae79c863. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

