### PR TITLE
Refactor ModelPrice compatibility parsing

### DIFF
--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -860,7 +860,7 @@ def _validate_model_price_value(value: Any) -> Decimal | TieredPrices | None:
     global _model_price_value_adapter
 
     if _model_price_value_adapter is None:
-        _model_price_value_adapter = pydantic.TypeAdapter(Decimal | TieredPrices | None)
+        _model_price_value_adapter = pydantic.TypeAdapter(Union[Decimal, TieredPrices, None])
     return _model_price_value_adapter.validate_python(value)
 
 

--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -842,11 +842,14 @@ def _model_price_mapping_from_constructor(data: Any) -> dict[str, Decimal | Tier
         return {}
     if not isinstance(data, Mapping):
         raise TypeError('_extra_prices must be a mapping')
-    return dict(cast(Mapping[str, Decimal | TieredPrices | None], data))
+    return dict(cast(Mapping[str, Union[Decimal, TieredPrices, None]], data))
 
 
 def _validate_model_price_data(data: Mapping[str, Any]) -> dict[str, Decimal | TieredPrices | None]:
-    prices = _model_price_mapping_from_constructor(data.get('_extra_prices'))
+    prices = {
+        key: _validate_model_price_value(value)
+        for key, value in _model_price_mapping_from_constructor(data.get('_extra_prices')).items()
+    }
     for key, value in data.items():
         if key != '_extra_prices':
             prices[key] = _validate_model_price_value(value)

--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeVar, Union, cast, overload
 
 import pydantic
+from pydantic_core import core_schema
 from typing_extensions import TypedDict, TypeGuard
 
 if TYPE_CHECKING:
@@ -678,72 +679,55 @@ class CalcPrice(TypedDict):
 
 
 class ModelPriceMeta(type):
+    """Let dataclass subclasses accept dynamic registry-backed price kwargs."""
+
     def __call__(cls: ModelPriceMeta, *args: Any, **kwargs: Any) -> ModelPrice:
         model_price_type = cast(type[ModelPrice], cls)
         if model_price_type is ModelPrice or not dataclasses.is_dataclass(model_price_type):
             return cast(ModelPrice, type.__call__(cls, *args, **kwargs))
 
         declared_fields = _model_price_declared_fields_for(model_price_type)
-        dynamic_prices = {
-            key: kwargs.pop(key)
-            for key in tuple(kwargs)
-            if key not in declared_fields and _is_registered_price_key(key)
-        }
+        stored_prices = kwargs.pop('_extra_prices', None)
+        dynamic_prices = _pop_dynamic_price_kwargs(kwargs, declared_fields)
         instance = cast(ModelPrice, type.__call__(cls, *args, **kwargs))
-        if dynamic_prices:
-            extra_prices = dict(getattr(instance, '_extra_prices', {}))
-            extra_prices.update(dynamic_prices)
-            object.__setattr__(instance, '_extra_prices', extra_prices)
+        extra_prices = dict(instance.__dict__.get('_extra_prices', {}))
+        extra_prices.update(_model_price_mapping_from_constructor(stored_prices))
+        extra_prices.update(dynamic_prices)
+        object.__setattr__(instance, '_extra_prices', extra_prices)
         return instance
 
 
-@dataclass
 class ModelPrice(metaclass=ModelPriceMeta):
     """Set of prices for using a model"""
 
-    # The active registry is the price-key list; legacy keys and future keys use
-    # the same internal storage so dataclass introspection is not misleading.
-    _extra_prices: dict[str, Decimal | TieredPrices | None] = dataclasses.field(
-        default_factory=dict, repr=False, compare=False
-    )
+    _extra_prices: dict[str, Decimal | TieredPrices | None]
 
     def __init__(self, **prices: Decimal | TieredPrices | None) -> None:
         raw_stored_prices = cast(Any, prices).pop('_extra_prices', None)
-        dynamic_prices: dict[str, Decimal | TieredPrices | None] = {}
-        if raw_stored_prices is not None:
-            if not isinstance(raw_stored_prices, Mapping):
-                raise TypeError('_extra_prices must be a mapping')
-            dynamic_prices.update(cast(Mapping[str, Decimal | TieredPrices | None], raw_stored_prices))
-        dynamic_prices.update(prices)
-        object.__setattr__(self, '_extra_prices', dynamic_prices)
+        stored_prices = _model_price_mapping_from_constructor(raw_stored_prices)
+        stored_prices.update(prices)
+        object.__setattr__(self, '_extra_prices', stored_prices)
 
-    @pydantic.model_validator(mode='before')
     @classmethod
-    def _store_unknown_price_keys(cls, data: Any) -> Any:
-        # providers_schema is a Pydantic TypeAdapter over stdlib dataclasses;
-        # Pydantic still invokes validators declared on those dataclasses.
-        if not isinstance(data, dict):
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> core_schema.CoreSchema:
+        return core_schema.no_info_plain_validator_function(cls._validate)
+
+    @classmethod
+    def _validate(cls, data: Any) -> ModelPrice:
+        if isinstance(data, cls):
             return data
 
-        raw_data = cast(dict[str, Any], data)
-        declared_fields = _model_price_declared_fields_for(cls)
-        extra_prices: dict[str, Any] = {key: value for key, value in raw_data.items() if key not in declared_fields}
-        if not extra_prices:
-            return raw_data
+        if not isinstance(data, Mapping):
+            raise ValueError('ModelPrice must be a mapping')
 
-        model_price_data = dict(raw_data)
-        stored_extra_prices = dict(cast(dict[str, Any], model_price_data.get('_extra_prices') or {}))
-        stored_extra_prices.update(extra_prices)
-        model_price_data['_extra_prices'] = stored_extra_prices
-        for key in extra_prices:
-            model_price_data.pop(key)
-        return model_price_data
+        try:
+            return cls(**_validate_model_price_data(cast(Mapping[str, Any], data)))
+        except TypeError as exc:
+            raise ValueError(str(exc)) from exc
 
     def __repr__(self) -> str:
         parts: list[str] = []
-        for field in dataclasses.fields(self):
-            if field.name == '_extra_prices':
-                continue
+        for field in _model_price_fields_for(type(self)):
             value = getattr(self, field.name)
             if value is not None:
                 parts.append(f'{field.name}={value!r}')
@@ -836,7 +820,48 @@ class ModelPrice(metaclass=ModelPriceMeta):
 
 
 def _model_price_declared_fields_for(model_price_type: type[ModelPrice]) -> frozenset[str]:
-    return frozenset(field.name for field in dataclasses.fields(model_price_type))
+    return frozenset(field.name for field in _model_price_fields_for(model_price_type))
+
+
+def _model_price_fields_for(model_price_type: type[ModelPrice]) -> tuple[dataclasses.Field[Any], ...]:
+    if not dataclasses.is_dataclass(model_price_type):
+        return ()
+    return dataclasses.fields(model_price_type)
+
+
+def _pop_dynamic_price_kwargs(
+    kwargs: dict[str, Any], declared_fields: frozenset[str]
+) -> dict[str, Decimal | TieredPrices | None]:
+    return {
+        key: kwargs.pop(key) for key in tuple(kwargs) if key not in declared_fields and _is_registered_price_key(key)
+    }
+
+
+def _model_price_mapping_from_constructor(data: Any) -> dict[str, Decimal | TieredPrices | None]:
+    if data is None:
+        return {}
+    if not isinstance(data, Mapping):
+        raise TypeError('_extra_prices must be a mapping')
+    return dict(cast(Mapping[str, Decimal | TieredPrices | None], data))
+
+
+def _validate_model_price_data(data: Mapping[str, Any]) -> dict[str, Decimal | TieredPrices | None]:
+    prices = _model_price_mapping_from_constructor(data.get('_extra_prices'))
+    for key, value in data.items():
+        if key != '_extra_prices':
+            prices[key] = _validate_model_price_value(value)
+    return prices
+
+
+_model_price_value_adapter: pydantic.TypeAdapter[Decimal | TieredPrices | None] | None = None
+
+
+def _validate_model_price_value(value: Any) -> Decimal | TieredPrices | None:
+    global _model_price_value_adapter
+
+    if _model_price_value_adapter is None:
+        _model_price_value_adapter = pydantic.TypeAdapter(Decimal | TieredPrices | None)
+    return _model_price_value_adapter.validate_python(value)
 
 
 def _is_registered_price_key(name: str) -> bool:

--- a/prices/src/prices/package_data.py
+++ b/prices/src/prices/package_data.py
@@ -4,7 +4,7 @@ import dataclasses
 import json
 import re
 import subprocess
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -176,6 +176,12 @@ def _collect_model_price_keys(model_price: object) -> set[str]:
             field_name for field_name, value in getattr(model_price, '_extra_prices', {}).items() if value is not None
         }
         return declared_keys | extra_keys
+
+    extra_prices = getattr(model_price, '_extra_prices', None)
+    if isinstance(extra_prices, Mapping):
+        return {
+            field_name for field_name, value in cast(Mapping[str, object], extra_prices).items() if value is not None
+        }
 
     raise TypeError(f'Unsupported model price type: {type(model_price).__name__}')
 

--- a/tests/test_custom_prices.py
+++ b/tests/test_custom_prices.py
@@ -266,6 +266,30 @@ def test_provider_parsing_preserves_tiered_model_prices() -> None:
     assert price.input_mtok.tiers[0].price == Decimal('2')
 
 
+def test_provider_parsing_validates_stored_extra_price_values() -> None:
+    providers = types.providers_schema.validate_python(
+        [
+            {
+                'id': 'testing',
+                'name': 'Testing',
+                'api_pattern': 'testing',
+                'models': [
+                    {
+                        'id': 'model',
+                        'match': {'equals': 'model'},
+                        'prices': {'_extra_prices': {'input_mtok': 1}},
+                    }
+                ],
+            }
+        ]
+    )
+
+    price = providers[0].models[0].prices
+    assert isinstance(price, types.ModelPrice)
+    assert price.input_mtok == Decimal('1')
+    assert isinstance(price.input_mtok, Decimal)
+
+
 def test_dynamic_model_price_assignment_and_deletion() -> None:
     price = types.ModelPrice()
 

--- a/tests/test_custom_prices.py
+++ b/tests/test_custom_prices.py
@@ -234,6 +234,38 @@ def test_provider_parsing_preserves_dynamic_model_price_keys() -> None:
     assert price.cache_image_read_mtok == Decimal('0.5')
 
 
+def test_provider_parsing_preserves_tiered_model_prices() -> None:
+    providers = types.providers_schema.validate_json(
+        json.dumps(
+            [
+                {
+                    'id': 'testing',
+                    'name': 'Testing',
+                    'api_pattern': 'testing',
+                    'models': [
+                        {
+                            'id': 'model',
+                            'match': {'equals': 'model'},
+                            'prices': {
+                                'input_mtok': {
+                                    'base': 1,
+                                    'tiers': [{'start': 100_000, 'price': 2}],
+                                },
+                            },
+                        }
+                    ],
+                }
+            ]
+        )
+    )
+
+    price = providers[0].models[0].prices
+    assert isinstance(price, types.ModelPrice)
+    assert isinstance(price.input_mtok, types.TieredPrices)
+    assert price.input_mtok.base == Decimal('1')
+    assert price.input_mtok.tiers[0].price == Decimal('2')
+
+
 def test_dynamic_model_price_assignment_and_deletion() -> None:
     price = types.ModelPrice()
 


### PR DESCRIPTION
## Summary
- make runtime ModelPrice a plain class with local Pydantic core validation for price mappings
- keep dataclass subclass constructor compatibility via a smaller metaclass bridge
- teach package-data validation to read plain runtime ModelPrice _extra_prices
- add coverage for tiered price parsing through providers_schema

## Tests
- uv run ruff check packages/python/genai_prices/types.py prices/src/prices/package_data.py tests/test_custom_prices.py
- uv run basedpyright packages/python/genai_prices/types.py prices/src/prices/package_data.py tests/test_custom_prices.py
- uv run pytest tests/test_custom_prices.py tests/test_units.py tests/test_update_prices.py tests/test_price_calc.py tests/test_tiered_pricing.py
- uv run pytest

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `ModelPrice` into a plain class with local `pydantic_core` validation and kept dataclass-subclass compatibility. This stabilizes dynamic price key parsing, validates stored extra price values, preserves tiered prices from `providers_schema`, and fixes parsing on Python 3.9.

- **Refactors**
  - Made `ModelPrice` a plain class with a small metaclass bridge for dataclass subclasses.
  - Added `__get_pydantic_core_schema__` no-info validator for mapping input and `Decimal | TieredPrices | None` values.
  - Unified `_extra_prices` with dynamic kwargs; improved repr/field detection; `package_data` now reads `_extra_prices` mappings.

- **Bug Fixes**
  - Fixed parser on Python 3.9 by avoiding dataclass-only introspection and using the core-schema validator with a cached `pydantic.TypeAdapter`.
  - Validated values in `_extra_prices` so stored extras parse to `Decimal`/`TieredPrices` and error on invalid types.

<sup>Written for commit 7c897695922b94d1e42488c135ff5efca66d37d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

