### PR TITLE
Prep 0.0.61 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7579,7 +7579,7 @@
     },
     "packages/js": {
       "name": "@pydantic/genai-prices",
-      "version": "0.0.60",
+      "version": "0.0.61",
       "license": "MIT",
       "dependencies": {
         "yargs": "^17.7.2"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/genai-prices",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "description": "Calculate prices for calling LLM inference APIs",
   "author": "Pydantic Team",
   "type": "module",

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "genai-prices"
-version = "0.0.60"
+version = "0.0.61"
 description = "Calculate prices for calling LLM inference APIs."
 readme = "README.md"
 authors = [{ name = "Samuel Colvin", email = "samuel@pydantic.dev" }]

--- a/uv.lock
+++ b/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.60"
+version = "0.0.61"
 source = { editable = "packages/python" }
 dependencies = [
     { name = "eval-type-backport", marker = "python_full_version < '3.10'" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare 0.0.61 release across JS and Python packages. Bumps `@pydantic/genai-prices` and `genai-prices` to 0.0.61 and updates `package-lock.json` and `uv.lock` for publishing.

<sup>Written for commit 2e887b2644685cf951140a58cea7b2f96521742f. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/genai-prices/pull/377?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

