### PR TITLE
refactor: move httpx2 from httpx

### DIFF
--- a/packages/python/genai_prices/update_prices.py
+++ b/packages/python/genai_prices/update_prices.py
@@ -6,7 +6,7 @@ import threading
 from dataclasses import dataclass, field
 from time import time
 
-import httpx
+import httpx2
 
 from . import data_snapshot
 
@@ -59,7 +59,7 @@ class UpdatePrices:
     """How often to update prices in seconds."""
     url: str = DEFAULT_UPDATE_URL
     """The URL to fetch prices from."""
-    request_timeout: httpx.Timeout = field(default_factory=lambda: httpx.Timeout(timeout=10, connect=5))
+    request_timeout: httpx2.Timeout = field(default_factory=lambda: httpx2.Timeout(timeout=10, connect=5))
     """The timeout for HTTP requests."""
     _stop_event: threading.Event = field(default_factory=threading.Event)
     _prices_updated: threading.Event = field(default_factory=threading.Event)
@@ -161,6 +161,6 @@ class UpdatePrices:
         """Fetches the latest provider data from the configured URL."""
         from . import data
 
-        r = httpx.get(self.url, timeout=self.request_timeout)
+        r = httpx2.get(self.url, timeout=self.request_timeout)
         r.raise_for_status()
         return data_snapshot.DataSnapshot(data.providers_schema.validate_json(r.content), from_auto_update=True)

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Internet",
 ]
 dependencies = [
-    "httpx>=0.27",
+    "httpx2>=2.0",
     "pydantic>=2.10",
 ]
 

--- a/prices/pyproject.toml
+++ b/prices/pyproject.toml
@@ -10,4 +10,4 @@ readme = "README.md"
 # Do not publish this package to PyPI
 classifiers = ["Private :: do not release"]
 requires-python = ">=3.10"
-dependencies = ["httpx>=0.27", "pydantic>=2.10", "ruamel-yaml>=0.18.14"]
+dependencies = ["httpx2>=2.0", "pydantic>=2.10", "ruamel-yaml>=0.18.14"]

--- a/prices/src/prices/source_huggingface.py
+++ b/prices/src/prices/source_huggingface.py
@@ -2,7 +2,7 @@ from operator import attrgetter
 from pathlib import Path
 from typing import Any, cast
 
-import httpx
+import httpx2
 from pydantic import HttpUrl
 
 from prices.collapse import collapse_provider
@@ -41,7 +41,7 @@ def get_model_infos(models: list[dict[str, Any]], provider: str):
 
 
 def main():
-    models = httpx.get('https://router.huggingface.co/v1/models').json()['data']
+    models = httpx2.get('https://router.huggingface.co/v1/models').json()['data']
 
     providers = {p['provider'] for model in models for p in model['providers']}
     providers_dir = Path(__file__).parent / '../../providers'

--- a/prices/src/prices/source_litellm.py
+++ b/prices/src/prices/source_litellm.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-import httpx
+import httpx2
 from pydantic import BaseModel, OnErrorOmit, TypeAdapter
 
 from . import source_prices
@@ -52,7 +52,7 @@ lookup_provider = {
 def get_litellm_prices():
     """Get prices from LiteLLM code."""
     url = 'https://raw.githubusercontent.com/BerriAI/litellm/refs/heads/main/model_prices_and_context_window.json'
-    r = httpx.get(url)
+    r = httpx2.get(url)
     r.raise_for_status()
     response_data = lite_llm_response_schema.validate_json(r.content)
 

--- a/prices/src/prices/source_openrouter.py
+++ b/prices/src/prices/source_openrouter.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Literal
 
-import httpx
+import httpx2
 from pydantic import BaseModel
 
 from . import source_prices
@@ -88,7 +88,7 @@ class OpenRouterResponse(BaseModel):
 
 def main(mode: Literal['metadata', 'prices']):  # noqa: C901
     """Update provider prices and metadata based on OpenRouter API."""
-    r = httpx.get('https://openrouter.ai/api/v1/models')
+    r = httpx2.get('https://openrouter.ai/api/v1/models')
     r.raise_for_status()
 
     or_response = OpenRouterResponse.model_validate_json(r.content)

--- a/prices/src/prices/source_ovhcloud.py
+++ b/prices/src/prices/source_ovhcloud.py
@@ -3,7 +3,7 @@ from operator import attrgetter
 from pathlib import Path
 from typing import Any, cast
 
-import httpx
+import httpx2
 from pydantic import HttpUrl
 
 from prices.collapse import collapse_provider
@@ -60,7 +60,7 @@ def main():
     api_url = 'https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/models'
 
     try:
-        response = httpx.get(api_url, timeout=30.0)
+        response = httpx2.get(api_url, timeout=30.0)
         response.raise_for_status()
         data = response.json()
         models = data.get('data', [])

--- a/prices/src/prices/source_simonw_prices.py
+++ b/prices/src/prices/source_simonw_prices.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-import httpx
+import httpx2
 from pydantic import BaseModel, OnErrorOmit, TypeAdapter
 
 from . import source_prices
@@ -24,7 +24,7 @@ simonw_response_schema = TypeAdapter(dict[str, OnErrorOmit[SimonWModel]])
 def get_simonw_prices():
     """Get prices from github.com/simonw/llm-prices."""
     url = 'https://www.llm-prices.com/current-v1.json'
-    r = httpx.get(url)
+    r = httpx2.get(url)
     r.raise_for_status()
     response_data = simonw_response_schema.validate_json(r.content)
 

--- a/tests/cassettes/test_update_prices/fail.yaml
+++ b/tests/cassettes/test_update_prices/fail.yaml
@@ -11,7 +11,7 @@ interactions:
       host:
       - demo-endpoints.pydantic.workers.dev
       user-agent:
-      - python-httpx/0.28.1
+      - python-httpx2/2.2.0
     method: GET
     uri: https://demo-endpoints.pydantic.workers.dev/bin?status=404
   response:

--- a/tests/cassettes/test_update_prices/success.yaml
+++ b/tests/cassettes/test_update_prices/success.yaml
@@ -11,7 +11,7 @@ interactions:
         host:
           - raw.githubusercontent.com
         user-agent:
-          - python-httpx/0.28.1
+          - python-httpx2/2.2.0
       method: GET
       uri: https://raw.githubusercontent.com/pydantic/genai-prices/refs/heads/main/prices/data.json
     response:

--- a/tests/test_update_prices.py
+++ b/tests/test_update_prices.py
@@ -1,7 +1,7 @@
 import threading
 from decimal import Decimal
 
-import httpx
+import httpx2
 import pytest
 from inline_snapshot import snapshot
 
@@ -31,7 +31,7 @@ def _mock_update_prices_get(monkeypatch: pytest.MonkeyPatch, content: bytes = PR
         def raise_for_status(self) -> None:
             pass
 
-    def fake_get(url: str, timeout: httpx.Timeout) -> Response:
+    def fake_get(url: str, timeout: httpx2.Timeout) -> Response:
         assert url in {
             'https://example.test/prices.json',
             'https://raw.githubusercontent.com/pydantic/genai-prices/refs/heads/main/prices/data.json',
@@ -39,7 +39,7 @@ def _mock_update_prices_get(monkeypatch: pytest.MonkeyPatch, content: bytes = PR
         assert timeout is not None
         return Response(content)
 
-    monkeypatch.setattr(httpx, 'get', fake_get)
+    monkeypatch.setattr(httpx2, 'get', fake_get)
 
 
 def test_update_prices_fetch_parses_provider_array(monkeypatch: pytest.MonkeyPatch):
@@ -113,7 +113,7 @@ def test_update_prices_stop_clears_snapshot_after_in_flight_fetch(monkeypatch: p
         def raise_for_status(self) -> None:
             pass
 
-    def fake_get(url: str, timeout: httpx.Timeout) -> Response:
+    def fake_get(url: str, timeout: httpx2.Timeout) -> Response:
         assert url == 'https://example.test/prices.json'
         assert timeout is not None
         fetch_started.set()
@@ -126,7 +126,7 @@ def test_update_prices_stop_clears_snapshot_after_in_flight_fetch(monkeypatch: p
         except BaseException as exc:
             stop_errors.append(exc)
 
-    monkeypatch.setattr(httpx, 'get', fake_get)
+    monkeypatch.setattr(httpx2, 'get', fake_get)
     update_prices = UpdatePrices(url='https://example.test/prices.json', update_interval=3600)
     update_prices.start()
     try:
@@ -153,7 +153,7 @@ def test_update_prices_stop_clears_snapshot_after_in_flight_fetch(monkeypatch: p
 def test_update_prices_failed():
     assert data_snapshot._custom_snapshot is None
     with UpdatePrices(url='https://demo-endpoints.pydantic.workers.dev/bin?status=404') as update_prices:
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(httpx2.HTTPStatusError):
             update_prices.wait()
     assert data_snapshot._custom_snapshot is None
 
@@ -164,7 +164,7 @@ def test_update_prices_failed_stop():
     assert data_snapshot._custom_snapshot is None
     update_prices = UpdatePrices(url='https://demo-endpoints.pydantic.workers.dev/bin?status=404')
     update_prices.start()
-    with pytest.raises(httpx.HTTPStatusError):
+    with pytest.raises(httpx2.HTTPStatusError):
         update_prices.stop()
     assert data_snapshot._custom_snapshot is None
 

--- a/uv.lock
+++ b/uv.lock
@@ -295,7 +295,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -316,7 +316,7 @@ name = "genai-prices"
 version = "0.0.61"
 source = { editable = "packages/python" }
 dependencies = [
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "pydantic" },
 ]
 
@@ -329,7 +329,7 @@ cli = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx2", specifier = ">=2.0" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", marker = "extra == 'cli'", specifier = ">=2.11" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=14.3.2" },
@@ -395,31 +395,31 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/7e/8ab39aab1d392845b6512009a9be57d24a5bd4ec7a22d02e513d0645e7a8/httpcore2-2.2.0.tar.gz", hash = "sha256:10e0e142f1ecc1c1cb2a9ebbce82e57f16169f61d163ea336abf36799e89294b", size = 63533, upload-time = "2026-05-17T05:29:55.836Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/39/22/64de17e7956e8c002f7558ed667d924c2a288344aeff4bd8ff5dc5fdb70b/httpcore2-2.2.0-py3-none-any.whl", hash = "sha256:ce859f268bf8d34fa2d7753e09e4dd5194f557e1b3038439b68a89b2999572fa", size = 79288, upload-time = "2026-05-17T05:29:52.56Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
-    { name = "httpcore" },
+    { name = "httpcore2" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/aa/c3119de1aa7ad870a01aaddbf3bc3445ed9a681c31d45e3838fd8b7bc155/httpx2-2.2.0.tar.gz", hash = "sha256:f3428d59b1752b8f5629826277262fb4d65e3a683f48af8a5b16c4d012e0b801", size = 80477, upload-time = "2026-05-17T05:29:57.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e0/e0a52596c14194e428c20de4903f4abec38c0dfb5364d20f1d4a2b6266ef/httpx2-2.2.0-py3-none-any.whl", hash = "sha256:12347ebd2daeaefd50b529359778fff767082a09c5826752c963e71269722ff0", size = 74083, upload-time = "2026-05-17T05:29:54.543Z" },
 ]
 
 [[package]]
@@ -792,14 +792,14 @@ name = "prices"
 version = "0.0.0"
 source = { editable = "prices" }
 dependencies = [
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "pydantic" },
     { name = "ruamel-yaml" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx2", specifier = ">=2.0" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "ruamel-yaml", specifier = ">=0.18.14" },
 ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the codebase from `httpx` to `httpx2` for all HTTP requests to align with the new API and ensure future compatibility. No functional changes expected.

- **Refactors**
  - Replaced `httpx` imports and `.get(...)` calls with `httpx2` in price sources and `UpdatePrices`.
  - Updated `UpdatePrices.request_timeout` to use `httpx2.Timeout`.
  - Adjusted tests to mock `httpx2`, update expected exceptions, and refresh cassette User-Agent strings.

- **Dependencies**
  - Changed `packages/python/pyproject.toml` and `prices/pyproject.toml` from `httpx>=0.27` to `httpx2>=2.0`.
  - Updated `uv.lock` to include `httpx2` and `httpcore2`.

<sup>Written for commit 3165e7ec505f1c37f180cfd94daf41417d4c503b. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/genai-prices/pull/385?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

