### PR TITLE
Prep 0.0.62 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7579,7 +7579,7 @@
     },
     "packages/js": {
       "name": "@pydantic/genai-prices",
-      "version": "0.0.61",
+      "version": "0.0.62",
       "license": "MIT",
       "dependencies": {
         "yargs": "^17.7.2"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/genai-prices",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "description": "Calculate prices for calling LLM inference APIs",
   "author": "Pydantic Team",
   "type": "module",

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "genai-prices"
-version = "0.0.61"
+version = "0.0.62"
 description = "Calculate prices for calling LLM inference APIs."
 readme = "README.md"
 authors = [{ name = "Samuel Colvin", email = "samuel@pydantic.dev" }]

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.61"
+version = "0.0.62"
 source = { editable = "packages/python" }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare the 0.0.62 release by bumping versions for `@pydantic/genai-prices` (JS) and `genai-prices` (Python) and syncing lockfiles. No code changes; version updates only.

<sup>Written for commit 6486759cc74e58f632738599433d235708f7ab2a. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/genai-prices/pull/387?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

