### PR TITLE
fix(openrouter): skip models with adaptive/negative pricing

### DIFF
--- a/prices/src/prices/source_openrouter.py
+++ b/prices/src/prices/source_openrouter.py
@@ -81,6 +81,34 @@ class OpenRouterPricing(BaseModel, extra='forbid'):
             output_mtok=mtok(self.completion),
         )
 
+    def has_negative_price(self) -> bool:
+        # OpenRouter reports a price of -1 for models whose cost is adaptive/dynamic rather than a
+        # fixed per-token rate, so there is no single number we can store. Two kinds of model do this:
+        #   - auto-routers / meta-models that pick an underlying model per request, e.g.
+        #     `openrouter/auto`, `openrouter/fusion`, `openrouter/pareto-code`, `openrouter/bodybuilder`.
+        #   - `~`-prefixed "latest" aliases that redirect to whatever the newest model in a family is,
+        #     e.g. `~anthropic/claude-fable-latest` ("always redirects to the latest model in the Claude
+        #     Fable family"). This one is what first tripped this and crashed the whole pull on
+        #     ModelPrice validation.
+        # In both cases the resolved model (and price) varies per request, so -1 is a sentinel.
+        #
+        # ModelPrice requires positive prices, so we skip these models entirely for now.
+        # TODO: represent adaptive/dynamic pricing instead of dropping these models.
+        return any(
+            v is not None and v < 0
+            for v in (
+                self.audio,
+                self.prompt,
+                self.completion,
+                self.request,
+                self.image,
+                self.web_search,
+                self.internal_reasoning,
+                self.input_cache_write,
+                self.input_cache_read,
+            )
+        )
+
 
 class OpenRouterResponse(BaseModel):
     data: list[OpenRouterModel]
@@ -105,6 +133,9 @@ def main(mode: Literal['metadata', 'prices']):  # noqa: C901
         provider_id = or_model.provider_id()
         if provider_id == 'openrouter':
             # this model is invalid
+            continue
+        if or_model.pricing.has_negative_price():
+            # variable/dynamic pricing we can't represent as a fixed price, skip it
             continue
         if models := or_providers.get(provider_id):
             models.append(or_model)


### PR DESCRIPTION
## Problem

`make` / `uv run -m prices update_from_openrouter` crashes during the model pull with a `ModelPrice` validation error:

```
pydantic_core._pydantic_core.ValidationError: 4 validation errors for ModelPrice
input_mtok.decimal
  Input should be greater than 0 [type=greater_than, input_value=Decimal('-1000000'), ...]
```

OpenRouter reports a price of **`-1`** for models whose cost is **adaptive/dynamic** rather than a fixed per-token rate, so `-1` is a sentinel, not a real price. Two kinds of model do this:

- **Auto-routers / meta-models** that pick an underlying model per request: `openrouter/auto`, `openrouter/fusion`, `openrouter/pareto-code`, `openrouter/bodybuilder`.
- **`~`-prefixed "latest" aliases** that redirect to the newest model in a family, e.g. `~anthropic/claude-fable-latest` (*"always redirects to the latest model in the Claude Fable family"*) — this is the one that first tripped the crash.

`ModelPrice` requires positive prices, so a single such model aborts the entire pull.

## Fix

Detect any negative price field on an OpenRouter model and skip it during the pull, so `update_from_openrouter` completes instead of crashing. A `TODO` is left to represent adaptive/dynamic pricing properly rather than dropping these models.

This unblocks running the OpenRouter sync again (which is currently impossible). The actual data refresh is intentionally **not** included here — running the sync surfaces duplicates (OpenRouter IDs vs. curated IDs) and a model-match overlap that need manual curation, so that's a separate follow-up.

## Notes

- `prices/src/prices/**` is intentionally excluded from coverage and has no test suite, so no test is added (consistent with the rest of the build tooling).