### PR TITLE
Prep 0.0.66 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7579,7 +7579,7 @@
     },
     "packages/js": {
       "name": "@pydantic/genai-prices",
-      "version": "0.0.65",
+      "version": "0.0.66",
       "license": "MIT",
       "dependencies": {
         "yargs": "^17.7.2"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/genai-prices",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "description": "Calculate prices for calling LLM inference APIs",
   "author": "Pydantic Team",
   "type": "module",

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "genai-prices"
-version = "0.0.65"
+version = "0.0.66"
 description = "Calculate prices for calling LLM inference APIs."
 readme = "README.md"
 authors = [{ name = "Samuel Colvin", email = "samuel@pydantic.dev" }]

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.65"
+version = "0.0.66"
 source = { editable = "packages/python" }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
Version bump to 0.0.66.

Releases the following changes merged since v0.0.65:
- fix(openrouter): skip models with adaptive/negative pricing (#400)
- feat: add MiniMax and Zhipu AI providers, add kimi-k2.6 (#386)
- Add Claude Fable 5 pricing (#399)