### PR TITLE
fix(openrouter): preserve mirror model IDs

### DIFF
--- a/prices/src/prices/source_openrouter.py
+++ b/prices/src/prices/source_openrouter.py
@@ -37,14 +37,16 @@ class OpenRouterModel(BaseModel):
     def provider_name(self) -> str:
         return self.name.split(':', 1)[0].strip()
 
-    def model_id(self) -> str:
+    def model_id(self, *, strip_provider: bool = True) -> str:
+        if not strip_provider:
+            return self.id
         return self.id.split('/', 1)[1]
 
     def model_name(self) -> str:
         return self.name.split(':', 1)[-1].strip()
 
-    def model_info(self, inc_description: bool = True) -> ModelInfo:
-        model_id = self.model_id()
+    def model_info(self, inc_description: bool = True, *, strip_provider: bool = True) -> ModelInfo:
+        model_id = self.model_id(strip_provider=strip_provider)
 
         if inc_description:
             description = self.description.split('\n\n', 1)[0]
@@ -143,7 +145,7 @@ def main(mode: Literal['metadata', 'prices']):  # noqa: C901
             or_providers[provider_id] = [or_model]
 
         # add all models to the openrouter provider
-        model_info = or_model.model_info(inc_description=False)
+        model_info = or_model.model_info(inc_description=False, strip_provider=False)
         assert isinstance(model_info.prices, ModelPrice)
         try:
             or_provider_yaml.update_model(model_info.id, model_info)

--- a/tests/test_price_calc.py
+++ b/tests/test_price_calc.py
@@ -70,6 +70,18 @@ def test_openrouter_deepseek_v32_price():
     assert price.provider.id == snapshot('openrouter')
 
 
+@pytest.mark.parametrize('model_ref', ['deepseek/deepseek-v3.2', 'google/gemini-2.5-flash-lite'])
+def test_openrouter_response_model_refs_priceable_by_api_url(model_ref: str):
+    price = calc_price(
+        Usage(input_tokens=1_000, output_tokens=100),
+        model_ref=model_ref,
+        provider_api_url='https://openrouter.ai/api/v1',
+    )
+
+    assert price.model.id == model_ref
+    assert price.provider.id == 'openrouter'
+
+
 def test_tiered_prices():
     price = calc_price(Usage(input_tokens=500_000), model_ref='gemini-1.5-flash', provider_id='google')
     # Google uses threshold-based pricing: if context > 128K, ALL tokens charged at tier price

--- a/tests/test_price_calc.py
+++ b/tests/test_price_calc.py
@@ -71,7 +71,7 @@ def test_openrouter_deepseek_v32_price():
 
 
 @pytest.mark.parametrize('model_ref', ['deepseek/deepseek-v3.2', 'google/gemini-2.5-flash-lite'])
-def test_openrouter_response_model_refs_priceable_by_api_url(model_ref: str):
+def test_openrouter_api_model_refs_priceable_by_api_url(model_ref: str):
     price = calc_price(
         Usage(input_tokens=1_000, output_tokens=100),
         model_ref=model_ref,

--- a/tests/test_source_openrouter.py
+++ b/tests/test_source_openrouter.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from prices.prices_types import ClauseEquals
+from prices.source_openrouter import OpenRouterModel, OpenRouterPricing
+
+
+def openrouter_model(model_id: str) -> OpenRouterModel:
+    return OpenRouterModel(
+        id=model_id,
+        canonical_slug=model_id.lstrip('~'),
+        name=f'Test: {model_id}',
+        created=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        description='Test description\n\nMore details',
+        context_length=1_000_000,
+        pricing=OpenRouterPricing(prompt=Decimal('0.000001'), completion=Decimal('0.000002')),
+        supported_parameters=[],
+    )
+
+
+@pytest.mark.parametrize('model_id', ['google/gemini-3.5-flash', '~anthropic/claude-fable-latest'])
+def test_openrouter_provider_model_info_preserves_api_model_id(model_id: str):
+    model_info = openrouter_model(model_id).model_info(inc_description=False, strip_provider=False)
+
+    assert model_info.id == model_id
+    assert model_info.match == ClauseEquals(equals=model_id)
+    assert model_info.description is None
+
+
+@pytest.mark.parametrize(
+    ('model_id', 'native_model_id'),
+    [
+        ('google/gemini-3.5-flash', 'gemini-3.5-flash'),
+        ('~anthropic/claude-fable-latest', 'claude-fable-latest'),
+    ],
+)
+def test_native_provider_model_info_uses_native_model_id(model_id: str, native_model_id: str):
+    model_info = openrouter_model(model_id).model_info()
+
+    assert model_info.id == native_model_id
+    assert model_info.match == ClauseEquals(equals=native_model_id)
+    assert model_info.description == 'Test description'


### PR DESCRIPTION
## Summary

This adds a narrow guard for a failure mode exposed by the recent OpenRouter sync work: the OpenRouter provider mirror must use OpenRouter API model IDs verbatim, while native provider curation can continue to use provider-native model IDs.

Today `OpenRouterModel.model_id()` strips everything before the first `/`. That is correct for native provider additions, but it is wrong for `prices/providers/openrouter.yml`, which is intended to price OpenRouter model refs as OpenRouter exposes them.

## Why this is positive for the future

OpenRouter sync is a manual data-maintenance step, not part of the normal pre-commit flow. That is reasonable: running a live catalog sync in pre-commit would be slow, network-dependent, and would create noisy generated-data churn. The safer bottom-up guard is to make the sync code and tests encode the semantic invariant so the next manual sync cannot silently generate model refs that OpenRouter itself will not use.

This PR does that in two places:

- the OpenRouter mirror path now preserves `or_model.id` for `ModelInfo.id` and `match.equals`
- tests cover both sides of the split: OpenRouter mirror IDs stay namespaced/tilde-prefixed, while native-provider model info still strips to native IDs
- an OpenRouter API-ref contract test checks that representative OpenRouter model refs are priceable via `provider_api_url='https://openrouter.ai/api/v1'`

This is intentionally smaller than a full catalog refresh or scheduled auto-update system. It gives us a deterministic guard first, so future refreshes are less likely to produce an out-of-sync catalog.

## Context / precedence

Related OpenRouter lookup issues show this has been a recurring class of problem:

- #144 asked why OpenRouter prefix mismatches happened and whether they could be handled automatically
- #337 reported a downstream `msg.cost()` failure because OpenRouter data was stale/missing for `deepseek/deepseek-v3.2`
- #333 is another model-ref normalization failure involving routed provider model strings
- #283 explores a broader auto-update flow, but this PR is the smaller prerequisite invariant that makes manual or future automated syncs safer

## Test plan

- [x] `uv run --all-packages pytest tests/test_source_openrouter.py tests/test_price_calc.py::test_openrouter_api_model_refs_priceable_by_api_url -q`
- [x] `make format`
- [x] `make lint`
- [x] `uv run --all-packages basedpyright prices/src/prices/source_openrouter.py tests/test_source_openrouter.py tests/test_price_calc.py`
