### PR TITLE
Auto-release on data/source changes to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+# Auto-cuts a patch release whenever packaged data or package source lands on main,
+# so consumers can pin a fresh, specific version (instead of floating @latest or
+# hitting the raw.githubusercontent data.json from prod).
+#
+# Flow: bump patch across both packages -> commit + tag on main -> the tag push
+# triggers the `release-pypi` / `release-npm` jobs in ci.yml that actually publish.
+#
+# Required org setup (one-time):
+#   - A GitHub App with `contents: write`, installed on this repo.
+#   - Add the App to the `main` ruleset's bypass list (it pushes the bump commit + tag
+#     directly to the protected branch).
+#   - Repo variable  RELEASE_APP_ID            = the App's id
+#   - Repo secret     RELEASE_APP_PRIVATE_KEY  = the App's private key
+# (A fine-grained PAT with the same bypass works too; swap the app-token step for a
+#  `token: ${{ secrets.RELEASE_PAT }}` on checkout.)
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+    # Only the packaged artifacts / source — NOT the version files the bump itself
+    # touches (pyproject.toml, package.json, *.lock), so a release commit can't
+    # re-trigger this workflow.
+    paths:
+      - "packages/python/genai_prices/**"
+      - "packages/js/src/**"
+
+permissions:
+  contents: read
+
+# Serialise releases so two quick merges don't race on the same version number.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }} # zizmor: ignore[artipacked] -- credentials are required to push the bump commit and tag back to main
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+          package-manager-cache: false
+
+      - name: Bump patch version
+        env:
+          UV_FROZEN: "0"
+        run: |
+          uv version --package genai-prices --bump patch
+          npm version patch --no-git-tag-version --workspace=packages/js
+
+      - name: Read new version
+        id: version
+        run: echo "version=$(uv version --package genai-prices --short)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit, tag and push
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add packages/python/pyproject.toml packages/js/package.json uv.lock package-lock.json
+          git commit -m "Release v${VERSION}"
+          git tag "v${VERSION}"
+          git push origin HEAD:main
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" --generate-notes --verify-tag


### PR DESCRIPTION
## What

Auto-cut a patch release whenever **packaged data or package source** lands on `main`, so the Slack ask ("do releases whenever we merge to main") is satisfied without anyone hand-bumping versions or pushing tags.

The goal isn't to push people to `@latest` — it's the opposite: keep a **fresh, pinnable version always available** so a consumer can bump `genai-prices` to a specific version in the same PR where they switch a model, instead of either floating `@latest` or hitting the `raw.githubusercontent` `data.json` from prod (which not everyone wants to do).

## How

New `.github/workflows/release.yml`, on `push: main`:

1. Triggers only on changes to `packages/python/genai_prices/**` or `packages/js/src/**` (the packaged artifacts — `data.py` / `data.ts` — and source).
2. `uv version --package genai-prices --bump patch` + `npm version patch --workspace=packages/js` → bumps all 4 version files (`pyproject.toml`, `package.json`, `uv.lock`, `package-lock.json`) in lockstep.
3. Commits `Release vX.Y.Z` + tags + pushes to `main`.
4. The **tag push** triggers the existing `release-pypi` / `release-npm` jobs in `ci.yml` that actually publish. No change to the publish path.

**No re-trigger loop:** the version files the bump touches all sit *outside* the trigger `paths`, so a release commit can't re-fire the workflow. `concurrency: release` serialises back-to-back merges so they don't race on a version number.

## ⚠️ Required one-time org setup (workflow is inert until done)

The bump commit + tag push to **protected `main`**, so the default `GITHUB_TOKEN` won't do (can't bypass the ruleset; its pushes also wouldn't re-trigger CI). Need:

- A **GitHub App** with `contents: write`, installed on this repo.
- Add that App to the **`main` ruleset bypass list**.
- Repo **variable** `RELEASE_APP_ID` + repo **secret** `RELEASE_APP_PRIVATE_KEY`.

(A fine-grained PAT with the same bypass works as a simpler alternative — swap the `create-github-app-token` step for `token: ${{ secrets.RELEASE_PAT }}` on checkout.)

Opening as **draft** until the above is configured.

## Notes / deliberate scope

- **Trigger = packaged-data/source paths, not every merge.** Docs/CI/test-only merges don't cut a release. Covers both "latest prices" and "latest patches".
- **One redundant CI run per release:** the bump commit's push to `main` re-runs `ci.yml` tests (release jobs skipped — not a tag). Harmless; left as-is to avoid a `[skip ci]` that would also skip the tag's publish run (same SHA).
- **`@latest` is still not advertised anywhere** — this PR doesn't touch docs to encourage floating; it just makes pinning painless. Happy to add a short "two channels" note (pin a release vs. on-demand data fetch) in a follow-up if wanted.
- **Locally verified:** both bump commands touch exactly the 4 version files and land on matching `0.0.68`; `zizmor` passes on the workflow.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

