### PR TITLE
Prep 0.0.70 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7591,7 +7591,7 @@
     },
     "packages/js": {
       "name": "@pydantic/genai-prices",
-      "version": "0.0.69",
+      "version": "0.0.70",
       "license": "MIT",
       "dependencies": {
         "yargs": "^17.7.2"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/genai-prices",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "description": "Calculate prices for calling LLM inference APIs",
   "author": "Pydantic Team",
   "type": "module",

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "genai-prices"
-version = "0.0.69"
+version = "0.0.70"
 description = "Calculate prices for calling LLM inference APIs."
 readme = "README.md"
 authors = [{ name = "Samuel Colvin", email = "samuel@pydantic.dev" }]

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.69"
+version = "0.0.70"
 source = { editable = "packages/python" }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
Release with the usage extractor fixes for pydantic/pydantic-ai#4818: Bedrock Converse cache token extraction (#454, #439), Cohere `tokens` api_flavor (#453), and Groq cached/audio token mappings (#426, fixes #414).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

