### PR TITLE
ci: run release jobs when `check` succeeds despite skipped `version-guard`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,10 +149,11 @@ jobs:
 
   release-pypi:
     needs: [check]
-    # needs.check.result, not success(): version-guard is skipped on tag runs and a
-    # skipped job anywhere in the needs chain makes success() false, silently skipping
-    # the release jobs (v0.0.70 hit this).
-    if: needs.check.result == 'success' && startsWith(github.ref, 'refs/tags/')
+    # Not success(): version-guard is skipped on tag runs, and a skipped job anywhere
+    # in the needs chain makes success() false, silently skipping the release jobs
+    # (the v0.0.70 tag hit this). An explicit status function is required, otherwise
+    # an implicit success() is still applied to the expression.
+    if: ${{ !cancelled() && needs.check.result == 'success' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     environment:
       name: release-pypi
@@ -181,10 +182,11 @@ jobs:
 
   release-npm:
     needs: [check]
-    # needs.check.result, not success(): version-guard is skipped on tag runs and a
-    # skipped job anywhere in the needs chain makes success() false, silently skipping
-    # the release jobs (v0.0.70 hit this).
-    if: needs.check.result == 'success' && startsWith(github.ref, 'refs/tags/')
+    # Not success(): version-guard is skipped on tag runs, and a skipped job anywhere
+    # in the needs chain makes success() false, silently skipping the release jobs
+    # (the v0.0.70 tag hit this). An explicit status function is required, otherwise
+    # an implicit success() is still applied to the expression.
+    if: ${{ !cancelled() && needs.check.result == 'success' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     environment:
       name: release-npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,10 @@ jobs:
 
   release-pypi:
     needs: [check]
-    if: success() && startsWith(github.ref, 'refs/tags/')
+    # needs.check.result, not success(): version-guard is skipped on tag runs and a
+    # skipped job anywhere in the needs chain makes success() false, silently skipping
+    # the release jobs (v0.0.70 hit this).
+    if: needs.check.result == 'success' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment:
       name: release-pypi
@@ -178,7 +181,10 @@ jobs:
 
   release-npm:
     needs: [check]
-    if: success() && startsWith(github.ref, 'refs/tags/')
+    # needs.check.result, not success(): version-guard is skipped on tag runs and a
+    # skipped job anywhere in the needs chain makes success() false, silently skipping
+    # the release jobs (v0.0.70 hit this).
+    if: needs.check.result == 'success' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment:
       name: release-npm


### PR DESCRIPTION
The v0.0.70 tag run skipped `release-pypi` and `release-npm`: `version-guard` (added in #450) is PR-only and is skipped on tag runs, and a skipped job in the transitive needs chain makes `success()` false, so `if: success() && startsWith(github.ref, 'refs/tags/')` silently skipped both release jobs. `check` itself passes via `allowed-skips`. Gate on `needs.check.result == 'success'` instead, which reflects the alls-green verdict.

After merging, the v0.0.70 release and tag need to be recreated on the new main tip so the tag carries the fixed workflow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

