### PR TITLE
chore: gitignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,3 @@ packages/js/.genai-prices-cache.json
 
 # Local dev files and secrets
 .env
-.mcp.json
-AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ node_modules/
 .DS_Store
 packages/js/.genai-prices-cache.json
 .idea/
+
+# Local dev files and secrets
+.env
+.mcp.json
+AGENTS.md


### PR DESCRIPTION
Adds `.env` to `.gitignore` so it can never be committed accidentally — it can hold secrets (as one just did). Deliberately scoped to `.env` only; `.mcp.json`/`AGENTS.md` are fine to keep tracked.