### PR TITLE
fix: match compact dated model refs from LiteLLM/OpenRouter

### DIFF
--- a/packages/js/src/__tests__/matcher.test.ts
+++ b/packages/js/src/__tests__/matcher.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import type { Provider } from '../types'
 
 import { data } from '../data'
-import { matchLogic, matchModel, matchModelWithFallback, matchProvider } from '../engine'
+import { matchLogic, matchModel, matchModelWithFallback, matchProvider, normalizeCompactDatedRef } from '../engine'
 
 const actualProviders = data
 
@@ -86,6 +86,33 @@ describe('Model Matching with Fallback', () => {
       const model = matchModelWithFallback(azure!, 'gpt-4.1', actualProviders)
       expect(model).toBeDefined()
       expect(model?.id).toBe('gpt-4.1')
+    })
+
+    it('should resolve compact dated refs to the dashed alias', () => {
+      const openai = matchProvider(actualProviders, { providerId: 'openai' })
+      expect(openai).toBeDefined()
+
+      // LiteLLM/OpenRouter emit `gpt-5.2-20251211`, only the dashed form is aliased
+      const compact = matchModelWithFallback(openai!, 'gpt-5.2-20251211', actualProviders)
+      expect(compact?.id).toBe('gpt-5.2')
+      const dashed = matchModelWithFallback(openai!, 'gpt-5.2-2025-12-11', actualProviders)
+      expect(dashed?.id).toBe('gpt-5.2')
+    })
+
+    it('should not normalize refs that match on the compact date form', () => {
+      // Bedrock models match the compact date via `contains`, so they must be returned as-is
+      const aws = matchProvider(actualProviders, { providerId: 'aws' })
+      expect(aws).toBeDefined()
+      const model = matchModelWithFallback(aws!, 'claude-3-5-haiku-20241022', actualProviders)
+      expect(model?.id).toBe('regional.anthropic.claude-3-5-haiku-20241022-v1:0')
+    })
+
+    it('should only normalize valid compact dates', () => {
+      expect(normalizeCompactDatedRef('gpt-5.2-20251211')).toBe('gpt-5.2-2025-12-11')
+      expect(normalizeCompactDatedRef('claude-3-5-haiku-20241022')).toBe('claude-3-5-haiku-2024-10-22')
+      // suffixes that aren't a valid date are left untouched: bad year, then bad month
+      expect(normalizeCompactDatedRef('gpt-4o-12345678')).toBe('gpt-4o-12345678')
+      expect(normalizeCompactDatedRef('gpt-4o-20251301')).toBe('gpt-4o-20251301')
     })
 
     it('should fallback to other providers when model not found directly', () => {

--- a/packages/js/src/engine.ts
+++ b/packages/js/src/engine.ts
@@ -211,7 +211,28 @@ export function matchModel(models: ModelInfo[], modelId: string): ModelInfo | un
   return models.find((m) => matchLogic(m.match, modelId))
 }
 
+const COMPACT_DATE_RE = /(-)(20\d{2})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])(?=-|:|$)/g
+
+// Rewrite a compact date suffix like `-20251211` to the canonical `-2025-12-11` form. LiteLLM and
+// OpenRouter emit compact dated model refs (e.g. `gpt-5.2-20251211`) that don't match the dashed
+// aliases in the price data. Only used as a fallback, so models that match on the compact date form
+// are left untouched.
+export function normalizeCompactDatedRef(modelId: string): string {
+  return modelId.replace(COMPACT_DATE_RE, '$1$2-$3-$4')
+}
+
 export function matchModelWithFallback(provider: Provider, modelId: string, allProviders?: Provider[]): ModelInfo | undefined {
+  const model = matchModelDirect(provider, modelId, allProviders)
+  if (model) return model
+
+  // LiteLLM/OpenRouter emit compact dated refs like `gpt-5.2-20251211`; retry with the canonical
+  // dashed form if the ref didn't match as-is.
+  const normalized = normalizeCompactDatedRef(modelId)
+  if (normalized !== modelId) return matchModelDirect(provider, normalized, allProviders)
+  return undefined
+}
+
+function matchModelDirect(provider: Provider, modelId: string, allProviders?: Provider[]): ModelInfo | undefined {
   const model = matchModel(provider.models, modelId)
   if (model) return model
 
@@ -220,7 +241,7 @@ export function matchModelWithFallback(provider: Provider, modelId: string, allP
       const fallbackProvider = allProviders.find((p) => p.id === fallbackProviderId)
       if (fallbackProvider) {
         // don't pass allProviders when falling back, so we can only have one step of fallback
-        const fallbackModel = matchModelWithFallback(fallbackProvider, modelId)
+        const fallbackModel = matchModelDirect(fallbackProvider, modelId)
         if (fallbackModel) return fallbackModel
       }
     }

--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -264,6 +264,19 @@ class Usage:
         return self + other
 
 
+_COMPACT_DATE_RE = re.compile(r'(-)(20\d{2})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])(?=-|:|$)')
+
+
+def _normalize_compact_dated_ref(model_ref: str) -> str:
+    """Rewrite a compact date suffix like ``-20251211`` to the canonical ``-2025-12-11`` form.
+
+    LiteLLM and OpenRouter emit compact dated model refs (e.g. ``gpt-5.2-20251211``) that don't
+    match the dashed aliases used in the price data. This is only applied as a fallback when a ref
+    doesn't otherwise match, so models that match on the compact date form are left untouched.
+    """
+    return _COMPACT_DATE_RE.sub(r'\1\2-\3-\4', model_ref)
+
+
 @dataclass
 class Provider:
     """Information about an LLM inference provider"""
@@ -297,6 +310,16 @@ class Provider:
 
     def find_model(self, model_ref: str, *, all_providers: list[Provider] | None = None) -> ModelInfo | None:
         model_ref = model_ref.lower()
+        if model := self._match_model(model_ref, all_providers=all_providers):
+            return model
+        # LiteLLM/OpenRouter emit compact dated refs like `gpt-5.2-20251211`; retry with the
+        # canonical dashed form if the ref didn't match as-is.
+        normalized = _normalize_compact_dated_ref(model_ref)
+        if normalized != model_ref:
+            return self._match_model(normalized, all_providers=all_providers)
+        return None
+
+    def _match_model(self, model_ref: str, *, all_providers: list[Provider] | None = None) -> ModelInfo | None:
         for model in self.models:
             if model.is_match(model_ref):
                 return model
@@ -305,7 +328,7 @@ class Provider:
                 provider = next((p for p in all_providers if p.id == provider_id), None)
                 if provider:
                     # don't pass all_providers when falling back, so we can only have one step of fallback
-                    if model := provider.find_model(model_ref):
+                    if model := provider._match_model(model_ref):
                         return model
         return None
 

--- a/tests/test_model_matching.py
+++ b/tests/test_model_matching.py
@@ -417,6 +417,9 @@ test_cases: list[tuple[str, str, str]] = [
     ('openrouter', 'x-ai/grok-4.3-20260430', snapshot(('openrouter', 'x-ai/grok-4.3'))),
     ('xai', 'x-ai/grok-4.3-20260430', snapshot(('x-ai', 'grok-4.3'))),
     ('openrouter', 'google/gemini-3.5-flash-20260519', snapshot(('openrouter', 'google/gemini-3.5-flash'))),
+    ('openai', 'gpt-5.2-20251211', snapshot(('openai', 'gpt-5.2'))),
+    ('openai', 'gpt-5-2-20251211', snapshot(('openai', 'gpt-5.2'))),
+    ('azure', 'gpt-4.1-20250414', snapshot(('azure', 'gpt-4.1'))),
     pytest.param('openrouter', 'moonshotai/kimi-k2', None, marks=mark_xfail_todo),
 ]
 
@@ -649,6 +652,32 @@ def test_litellm_provider_id():
     provider, model = snapshot.find_provider_model('gpt-4o-mini-2024-07-18', None, 'litellm', None)
     assert provider.id == 'openai'
     assert model.id == 'gpt-4o-mini'
+
+
+def test_compact_dated_model_ref_normalized():
+    """Compact dated refs from LiteLLM/OpenRouter (e.g. `gpt-5.2-20251211`) fall back to the dashed alias."""
+    from genai_prices.types import _normalize_compact_dated_ref
+
+    snapshot = DataSnapshot(providers=providers, from_auto_update=False)
+    provider, model = snapshot.find_provider_model('openai/gpt-5.2-20251211', None, 'litellm', None)
+    assert (provider.id, model.id) == ('openai', 'gpt-5.2')
+
+    # a ref that already matches is unaffected by the normalization fallback
+    openai = find_provider_by_id(providers, 'openai')
+    assert openai is not None
+    assert openai.find_model('gpt-5.2-2025-12-11', all_providers=providers) is not None
+
+    # a model that matches on the compact date form (Bedrock `contains`) is returned as-is, not normalized away
+    aws = find_provider_by_id(providers, 'aws')
+    assert aws is not None
+    haiku = aws.find_model('claude-3-5-haiku-20241022', all_providers=providers)
+    assert haiku is not None and haiku.id == 'regional.anthropic.claude-3-5-haiku-20241022-v1:0'
+
+    assert _normalize_compact_dated_ref('gpt-5.2-20251211') == 'gpt-5.2-2025-12-11'
+    assert _normalize_compact_dated_ref('claude-3-5-haiku-20241022') == 'claude-3-5-haiku-2024-10-22'
+    # suffixes that aren't a valid date are left untouched: bad year, then bad month
+    assert _normalize_compact_dated_ref('gpt-4o-12345678') == 'gpt-4o-12345678'
+    assert _normalize_compact_dated_ref('gpt-4o-20251301') == 'gpt-4o-20251301'
 
 
 def test_litellm_unknown_prefix_falls_back_to_model_matching_error():


### PR DESCRIPTION
Fixes #333. A compact dated model ref like `gpt-5.2-20251211` (which LiteLLM and OpenRouter emit) fails the lookup because the price data only aliases the dashed `gpt-5.2-2025-12-11`. I made model matching retry with the compact date rewritten to the dashed form, but only as a fallback after the ref fails to match as-is, so models that match on the compact date form (like the Bedrock/Anthropic `contains` clauses) are left alone. The date regex is bounded to a valid year, month, and day, and the same change is mirrored in the Python and JS packages. Tested with `pytest tests/test_model_matching.py` (260 passed) and `npm test` in packages/js (634 passed), plus ruff, basedpyright, and tsc clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

