### PR TITLE
Optimize registry-backed pricing hot paths

### DIFF
--- a/packages/js/src/__tests__/calcPrice.test.ts
+++ b/packages/js/src/__tests__/calcPrice.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ModelPrice, TieredPrices, Usage } from '../types'
 
@@ -310,6 +310,33 @@ describe('Core Price Calculation Function', () => {
         output_price: 0,
         total_price: 44,
       })
+    })
+
+    it('should read and resolve each current model price once', () => {
+      const registry = getActiveRegistry()
+      const modelPrice: ModelPrice = {}
+      let priceReads = 0
+      Object.defineProperty(modelPrice, 'input_mtok', {
+        enumerable: true,
+        get: () => {
+          priceReads++
+          return 2
+        },
+      })
+      const unitLookup = vi.spyOn(registry.unitsByPriceKey, 'get')
+
+      try {
+        expect(calcPrice({ input_tokens: MILLION }, modelPrice, registry)).toEqual({
+          input_price: 2,
+          output_price: 0,
+          total_price: 2,
+        })
+        expect(priceReads).toBe(1)
+        expect(unitLookup).toHaveBeenCalledOnce()
+        expect(unitLookup).toHaveBeenCalledWith('input_mtok')
+      } finally {
+        unitLookup.mockRestore()
+      }
     })
 
     it('should reject missing ancestor prices before pricing', () => {

--- a/packages/js/src/__tests__/calcPrice.test.ts
+++ b/packages/js/src/__tests__/calcPrice.test.ts
@@ -1,15 +1,71 @@
 import { describe, expect, it } from 'vitest'
 
-import type { ModelPrice, Usage } from '../types'
+import type { ModelPrice, TieredPrices, Usage } from '../types'
 
-import { calcPrice } from '../engine'
-import { UnitRegistry } from '../units'
+import { calcPrice, collectResolvedModelPrices } from '../engine'
+import { getActiveRegistry, UnitRegistry } from '../units'
 
 const MILLION = 1_000_000
 
 function mtok(rate: number, tokens: number): number {
   return (rate * tokens) / MILLION
 }
+
+describe('collectResolvedModelPrices', () => {
+  const registry = getActiveRegistry()
+
+  it('handles empty and ordinary model prices', () => {
+    expect(collectResolvedModelPrices({}, registry)).toEqual([])
+    expect(collectResolvedModelPrices({ input_mtok: 1, output_mtok: 2 }, registry)).toEqual([
+      { price: 1, unit: registry.units.get('input_tokens') },
+      { price: 2, unit: registry.units.get('output_tokens') },
+    ])
+  })
+
+  it('retains overlap and request prices', () => {
+    expect(
+      collectResolvedModelPrices(
+        {
+          cache_audio_read_mtok: 4,
+          cache_read_mtok: 2,
+          input_audio_mtok: 3,
+          input_mtok: 1,
+          requests_kcount: 0.5,
+        },
+        registry
+      )
+    ).toEqual([
+      { price: 4, unit: registry.units.get('cache_audio_read_tokens') },
+      { price: 2, unit: registry.units.get('cache_read_tokens') },
+      { price: 3, unit: registry.units.get('input_audio_tokens') },
+      { price: 1, unit: registry.units.get('input_tokens') },
+      { price: 0.5, unit: registry.units.get('requests') },
+    ])
+  })
+
+  it('retains tiered prices and ignores undefined entries', () => {
+    const tieredPrice: TieredPrices = {
+      base: 1,
+      tiers: [{ price: 2, start: 100_000 }],
+    }
+
+    expect(collectResolvedModelPrices({ input_mtok: tieredPrice, output_mtok: undefined }, registry)).toEqual([
+      { price: tieredPrice, unit: registry.units.get('input_tokens') },
+    ])
+  })
+
+  it('uses the explicit registry and rejects unknown keys', () => {
+    const customRegistry = new UnitRegistry({
+      widgets: {
+        dimensions: { family: 'widgets' },
+        per: 1,
+      },
+    })
+
+    expect(collectResolvedModelPrices({ widgets: 2 }, customRegistry)).toEqual([{ price: 2, unit: customRegistry.units.get('widgets') }])
+    expect(() => collectResolvedModelPrices({ input_mtok: 1 }, customRegistry)).toThrow('Unknown price key: input_mtok')
+  })
+})
 
 describe('Core Price Calculation Function', () => {
   describe('calcPrice with separated input/output prices', () => {

--- a/packages/js/src/__tests__/validation.test.ts
+++ b/packages/js/src/__tests__/validation.test.ts
@@ -3,12 +3,13 @@ import { describe, expect, it } from 'vitest'
 import type { Provider, UsageExtractorMapping } from '../types'
 
 import { data } from '../data'
-import { UnitRegistry } from '../units'
+import { getActiveRegistry, UnitRegistry } from '../units'
 import {
   validateAncestorCoverage,
   validateExtractorDestinations,
   validateJoinCoverage,
   validateModelPrice,
+  validatePricedUnits,
   validatePriceKeys,
 } from '../validation'
 
@@ -112,6 +113,66 @@ describe('validateModelPrice', () => {
       validateModelPrice(['input_mtok', 'cache_read_mtok', 'input_audio_mtok'])
     }).toThrow('Missing join price key cache_audio_read_mtok for cache_read_mtok and input_audio_mtok')
   })
+
+  it('materializes single-pass price keys once', () => {
+    expect(() => {
+      validateModelPrice(oneShotPriceKeys(['input_mtok', 'cache_read_mtok']))
+    }).not.toThrow()
+  })
+})
+
+describe('validatePricedUnits', () => {
+  it('accepts valid resolved units including request-only pricing', () => {
+    const registry = getActiveRegistry()
+
+    expect(() => {
+      validatePricedUnits(
+        [requiredUnit(registry, 'input_mtok'), requiredUnit(registry, 'cache_read_mtok'), requiredUnit(registry, 'requests_kcount')],
+        registry
+      )
+    }).not.toThrow()
+    expect(() => {
+      validatePricedUnits([requiredUnit(registry, 'requests_kcount')], registry)
+    }).not.toThrow()
+  })
+
+  it('rejects missing ancestor and join prices with key-based error parity', () => {
+    const registry = getActiveRegistry()
+    const missingAncestorKeys = ['cache_read_mtok']
+    const missingJoinKeys = ['input_mtok', 'cache_read_mtok', 'input_audio_mtok']
+
+    expect(
+      validationError(() => {
+        validatePricedUnits(resolveUnits(registry, missingAncestorKeys), registry)
+      })
+    ).toBe(
+      validationError(() => {
+        validateModelPrice(missingAncestorKeys, registry)
+      })
+    )
+    expect(
+      validationError(() => {
+        validatePricedUnits(resolveUnits(registry, missingJoinKeys), registry)
+      })
+    ).toBe(
+      validationError(() => {
+        validateModelPrice(missingJoinKeys, registry)
+      })
+    )
+  })
+
+  it('validates units from an explicit custom registry', () => {
+    const registry = new UnitRegistry({
+      widgets: {
+        dimensions: { family: 'widgets' },
+        per: 1,
+      },
+    })
+
+    expect(() => {
+      validatePricedUnits([requiredUnit(registry, 'widgets')], registry)
+    }).not.toThrow()
+  })
 })
 
 describe('validateExtractorDestinations', () => {
@@ -187,4 +248,24 @@ function oneShotPriceKeys(keys: string[]): Iterable<string> {
       return keys[Symbol.iterator]()
     },
   }
+}
+
+function requiredUnit(registry: UnitRegistry, priceKey: string) {
+  const unit = registry.unitsByPriceKey.get(priceKey)
+  if (!unit) throw new Error(`Missing test unit for ${priceKey}`)
+  return unit
+}
+
+function resolveUnits(registry: UnitRegistry, priceKeys: string[]) {
+  return priceKeys.map((priceKey) => requiredUnit(registry, priceKey))
+}
+
+function validationError(validate: () => void): string {
+  try {
+    validate()
+  } catch (error) {
+    if (error instanceof Error) return error.message
+    throw error
+  }
+  throw new Error('Expected validation to fail')
 }

--- a/packages/js/src/engine.ts
+++ b/packages/js/src/engine.ts
@@ -1,8 +1,35 @@
 import { computeLeafValues } from './decompose'
-import { MatchLogic, ModelInfo, ModelPrice, ModelPriceCalculationResult, Provider, ProviderFindOptions, TieredPrices, Usage } from './types'
+import {
+  MatchLogic,
+  ModelInfo,
+  ModelPrice,
+  ModelPriceCalculationResult,
+  Provider,
+  ProviderFindOptions,
+  TieredPrices,
+  UnitDef,
+  Usage,
+} from './types'
 import { getActiveRegistry, UnitRegistry } from './units'
 import { getUsageValue } from './usage'
 import { validateModelPrice } from './validation'
+
+export type ResolvedPrice = Readonly<{
+  price: number | TieredPrices
+  unit: UnitDef
+}>
+
+export function collectResolvedModelPrices(modelPrice: ModelPrice, registry: UnitRegistry): ResolvedPrice[] {
+  const resolvedPrices: ResolvedPrice[] = []
+  for (const [priceKey, price] of Object.entries(modelPrice)) {
+    if (price === undefined) continue
+
+    const unit = registry.unitsByPriceKey.get(priceKey)
+    if (!unit) throw new Error(`Unknown price key: ${priceKey}`)
+    resolvedPrices.push({ price, unit })
+  }
+  return resolvedPrices
+}
 
 /**
  * Calculate price using threshold-based (cliff) pricing model.

--- a/packages/js/src/engine.ts
+++ b/packages/js/src/engine.ts
@@ -12,7 +12,7 @@ import {
 } from './types'
 import { getActiveRegistry, UnitRegistry } from './units'
 import { getUsageValue } from './usage'
-import { validateModelPrice } from './validation'
+import { validatePricedUnits } from './validation'
 
 export type ResolvedPrice = Readonly<{
   price: number | TieredPrices
@@ -70,30 +70,25 @@ function calcUnitPrice(price: number | TieredPrices | undefined, count: number |
 }
 
 export function calcPrice(usage: Usage, modelPrice: ModelPrice, registry: UnitRegistry = getActiveRegistry()): ModelPriceCalculationResult {
-  const effectivePriceKeys = Object.entries(modelPrice)
-    .filter(([, price]) => price !== undefined)
-    .map(([priceKey]) => priceKey)
-  validateModelPrice(effectivePriceKeys, registry)
+  const resolvedPrices = collectResolvedModelPrices(modelPrice, registry)
+  validatePricedUnits(
+    resolvedPrices.map(({ unit }) => unit),
+    registry
+  )
 
   let inputPrice = 0
   let outputPrice = 0
   let totalOnlyPrice = 0
 
-  const hasTieredPrice = effectivePriceKeys.some((priceKey) => isTieredPrice(modelPrice[priceKey]))
+  const hasTieredPrice = resolvedPrices.some(({ price }) => isTieredPrice(price))
   const totalInputTokens = hasTieredPrice ? getUsageValue(usage, 'input_tokens', registry) : 0
-  const pricedUnits = effectivePriceKeys.map((priceKey) => {
-    const unit = registry.unitsByPriceKey.get(priceKey)
-    if (!unit) throw new Error(`Unknown price key: ${priceKey}`)
-    return unit
-  })
-  const pricedUsageKeys = new Set(pricedUnits.filter((unit) => unit.usageKey !== 'requests').map((unit) => unit.usageKey))
+  const pricedUsageKeys = new Set(resolvedPrices.filter(({ unit }) => unit.usageKey !== 'requests').map(({ unit }) => unit.usageKey))
   const leafValues = computeLeafValues(pricedUsageKeys, usage, registry.units, registry)
-  if (pricedUnits.some((unit) => unit.usageKey === 'requests')) {
+  if (resolvedPrices.some(({ unit }) => unit.usageKey === 'requests')) {
     leafValues.requests = 1
   }
 
-  for (const unit of pricedUnits) {
-    const price = modelPrice[unit.priceKey]
+  for (const { price, unit } of resolvedPrices) {
     const unitPrice = calcUnitPrice(price, leafValues[unit.usageKey] ?? 0, totalInputTokens, unit.per)
     if (unit.dimensions.direction === 'input') {
       inputPrice += unitPrice

--- a/packages/js/src/validation.ts
+++ b/packages/js/src/validation.ts
@@ -11,13 +11,18 @@ export function validatePriceKeys(priceKeys: Iterable<string>, registry: UnitReg
 }
 
 export function validateAncestorCoverage(priceKeys: Iterable<string>, registry: UnitRegistry = getActiveRegistry()): void {
-  const effectivePriceKeys = [...priceKeys]
-  validatePriceKeys(effectivePriceKeys, registry)
-  const pricedKeys = new Set(effectivePriceKeys)
-  const pricedUnits = getUnitsForPriceKeys(pricedKeys, registry)
+  const pricedUnits = getUnitsForPriceKeys(priceKeys, registry)
+  validateResolvedAncestorCoverage(pricedUnits, registry)
+}
+
+function validateResolvedAncestorCoverage(pricedUnits: readonly UnitDef[], registry: UnitRegistry): void {
+  const pricedKeys = new Set(pricedUnits.map((unit) => unit.priceKey))
 
   for (const unit of pricedUnits) {
-    for (const ancestorUsageKey of registry.ancestorUsageKeys(unit.usageKey)) {
+    const ancestorUsageKeys = registry.ancestorUsageKeysByUsageKey.get(unit.usageKey)
+    if (!ancestorUsageKeys) throw new Error(`Unknown unit usage key: ${unit.usageKey}`)
+
+    for (const ancestorUsageKey of ancestorUsageKeys) {
       const ancestor = registry.units.get(ancestorUsageKey)
       if (ancestor && !pricedKeys.has(ancestor.priceKey)) {
         throw new Error(`Missing ancestor price key ${ancestor.priceKey} for ${unit.priceKey}`)
@@ -27,10 +32,12 @@ export function validateAncestorCoverage(priceKeys: Iterable<string>, registry: 
 }
 
 export function validateJoinCoverage(priceKeys: Iterable<string>, registry: UnitRegistry = getActiveRegistry()): void {
-  const effectivePriceKeys = [...priceKeys]
-  validatePriceKeys(effectivePriceKeys, registry)
-  const pricedKeys = new Set(effectivePriceKeys)
-  const pricedUnits = getUnitsForPriceKeys(pricedKeys, registry)
+  const pricedUnits = getUnitsForPriceKeys(priceKeys, registry)
+  validateResolvedJoinCoverage(pricedUnits, registry)
+}
+
+function validateResolvedJoinCoverage(pricedUnits: readonly UnitDef[], registry: UnitRegistry): void {
+  const pricedKeys = new Set(pricedUnits.map((unit) => unit.priceKey))
 
   for (let leftIndex = 0; leftIndex < pricedUnits.length; leftIndex++) {
     for (let rightIndex = leftIndex + 1; rightIndex < pricedUnits.length; rightIndex++) {
@@ -50,10 +57,12 @@ export function validateJoinCoverage(priceKeys: Iterable<string>, registry: Unit
 }
 
 export function validateModelPrice(priceKeys: Iterable<string>, registry: UnitRegistry = getActiveRegistry()): void {
-  const effectivePriceKeys = [...priceKeys]
-  validatePriceKeys(effectivePriceKeys, registry)
-  validateAncestorCoverage(effectivePriceKeys, registry)
-  validateJoinCoverage(effectivePriceKeys, registry)
+  validatePricedUnits(getUnitsForPriceKeys(priceKeys, registry), registry)
+}
+
+export function validatePricedUnits(pricedUnits: readonly UnitDef[], registry: UnitRegistry): void {
+  validateResolvedAncestorCoverage(pricedUnits, registry)
+  validateResolvedJoinCoverage(pricedUnits, registry)
 }
 
 export function validateExtractorDestinations(providerData: Provider[], registry: UnitRegistry = getActiveRegistry()): void {
@@ -70,8 +79,8 @@ export function validateExtractorDestinations(providerData: Provider[], registry
   }
 }
 
-function getUnitsForPriceKeys(priceKeys: Set<string>, registry: UnitRegistry): UnitDef[] {
-  return [...priceKeys].map((priceKey) => {
+function getUnitsForPriceKeys(priceKeys: Iterable<string>, registry: UnitRegistry): UnitDef[] {
+  return [...new Set(priceKeys)].map((priceKey) => {
     const unit = registry.unitsByPriceKey.get(priceKey)
     if (!unit) throw new Error(`Unknown price key: ${priceKey}`)
     return unit

--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -700,25 +700,27 @@ class ModelPrice:
     def calc_price(self, usage: AbstractUsage) -> CalcPrice:
         """Calculate the price of usage in USD with this model price."""
         from genai_prices.units import _get_registry  # pyright: ignore[reportPrivateUsage]
-        from genai_prices.validation import validate_model_price
+        from genai_prices.validation import validate_priced_units
 
         registry = _get_registry()
-        validate_model_price(_collect_effective_model_price_keys(self, registry), registry)
+        resolved_prices = _collect_resolved_model_prices(self, registry)
+        validate_priced_units(tuple(unit for unit, _ in resolved_prices), registry)
 
         usage_data = Usage.from_raw(usage)
-        priced_units = _collect_model_price_units(self, registry)
-        priced_counts = _compute_registry_priced_counts(priced_units, usage_data)
+        priced_counts = _compute_registry_priced_counts(resolved_prices, usage_data)
 
         input_price = Decimal(0)
         output_price = Decimal(0)
         total_price = Decimal(0)
         # Reading input_tokens can trigger lazy inference errors; only do it when
         # tiered pricing actually needs the threshold.
-        total_input_tokens = usage_data.input_tokens if _model_price_uses_tiered_prices(self, registry) else 0
+        total_input_tokens = (
+            usage_data.input_tokens if any(isinstance(price, TieredPrices) for _, price in resolved_prices) else 0
+        )
 
-        for unit in priced_units:
+        for unit, price in resolved_prices:
             unit_price = calc_unit_price(
-                getattr(self, unit.price_key),
+                price,
                 priced_counts[unit.usage_key],
                 total_input_tokens,
                 unit.per,
@@ -808,11 +810,13 @@ def calc_unit_price(
     return unit_price / per
 
 
-def _collect_effective_model_price_keys(model_price: ModelPrice, registry: UnitRegistry) -> set[str]:
+def _collect_effective_model_price_keys(  # pyright: ignore[reportUnusedFunction]
+    model_price: ModelPrice, registry: UnitRegistry
+) -> set[str]:
     return set(_iter_effective_model_price_keys(model_price, registry))
 
 
-def _collect_resolved_model_prices(  # pyright: ignore[reportUnusedFunction]
+def _collect_resolved_model_prices(
     model_price: ModelPrice, registry: UnitRegistry
 ) -> tuple[tuple[UnitDef, Decimal | TieredPrices], ...]:
     stored_prices = [
@@ -831,25 +835,22 @@ def _collect_resolved_model_prices(  # pyright: ignore[reportUnusedFunction]
     )
 
 
-def _model_price_uses_tiered_prices(model_price: ModelPrice, registry: UnitRegistry) -> bool:
-    return any(
-        isinstance(getattr(model_price, price_key), TieredPrices)
-        for price_key in _iter_effective_model_price_keys(model_price, registry)
-    )
-
-
-def _collect_model_price_units(model_price: ModelPrice, registry: UnitRegistry) -> tuple[UnitDef, ...]:
+def _collect_model_price_units(  # pyright: ignore[reportUnusedFunction]
+    model_price: ModelPrice, registry: UnitRegistry
+) -> tuple[UnitDef, ...]:
     return tuple(_iter_priced_registered_units(model_price, registry))
 
 
-def _compute_registry_priced_counts(priced_units: Sequence[UnitDef], usage: Usage) -> dict[str, int]:
+def _compute_registry_priced_counts(
+    resolved_prices: Sequence[tuple[UnitDef, Decimal | TieredPrices]], usage: Usage
+) -> dict[str, int]:
     from genai_prices.decompose import compute_leaf_values
 
     counts: dict[str, int] = {}
-    priced_units_by_usage_key = {unit.usage_key: unit for unit in priced_units if unit.usage_key != 'requests'}
+    priced_units_by_usage_key = {unit.usage_key: unit for unit, _ in resolved_prices if unit.usage_key != 'requests'}
     if priced_units_by_usage_key:
         counts.update(compute_leaf_values(set(priced_units_by_usage_key), usage, priced_units_by_usage_key))
-    if any(unit.usage_key == 'requests' for unit in priced_units):
+    if any(unit.usage_key == 'requests' for unit, _ in resolved_prices):
         counts['requests'] = 1
 
     return counts

--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -480,7 +480,7 @@ def _validate_usage_extractor_destinations(
 
     validate_extractor_destinations(
         {mapping.dest for mapping in mappings},
-        registry.reported_usage_keys() if registry is not None else _reported_usage_keys(),
+        registry.reported_usage_keys if registry is not None else _reported_usage_keys(),
     )
 
 
@@ -593,17 +593,13 @@ def _type_name(v: Any) -> str:
 def _reported_usage_keys() -> frozenset[str]:
     from genai_prices.units import _get_registry  # pyright: ignore[reportPrivateUsage]
 
-    # Phase 5 should benchmark/cache this active-registry key set and the
-    # corresponding registry-order tuple once registry validation identities exist.
-    return _get_registry().reported_usage_keys()
+    return _get_registry().reported_usage_keys
 
 
 def _reported_usage_key_order() -> tuple[str, ...]:
     from genai_prices.units import _get_registry  # pyright: ignore[reportPrivateUsage]
 
-    registry = _get_registry()
-    reported_keys = registry.reported_usage_keys()
-    return tuple(key for key in registry.units if key in reported_keys)
+    return _get_registry().reported_usage_keys_in_order
 
 
 def _raw_usage_value(obj: object, key: str) -> int | None:
@@ -856,11 +852,10 @@ def _iter_priced_registered_units(model_price: ModelPrice, registry: UnitRegistr
 
 
 def _iter_model_price_attr_items(model_price: ModelPrice, registry: UnitRegistry) -> Iterator[tuple[str, object]]:
-    registry_price_keys = {unit.price_key for unit in registry.units.values()}
     for key, value in model_price.__dict__.items():
         if key.startswith('_'):
             continue
-        if type(model_price) is not ModelPrice and key not in registry_price_keys:
+        if type(model_price) is not ModelPrice and key not in registry.all_price_keys:
             continue
         yield key, value
 

--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -812,6 +812,25 @@ def _collect_effective_model_price_keys(model_price: ModelPrice, registry: UnitR
     return set(_iter_effective_model_price_keys(model_price, registry))
 
 
+def _collect_resolved_model_prices(  # pyright: ignore[reportUnusedFunction]
+    model_price: ModelPrice, registry: UnitRegistry
+) -> tuple[tuple[UnitDef, Decimal | TieredPrices], ...]:
+    stored_prices = [
+        (price_key, value)
+        for price_key, value in _iter_model_price_attr_items(model_price, registry)
+        if value is not None
+    ]
+    unknown_price_keys = {price_key for price_key, _ in stored_prices if price_key not in registry.all_price_keys}
+    if unknown_price_keys:
+        bad_keys = ', '.join(sorted(unknown_price_keys))
+        raise ValueError(f'Unknown price key: {bad_keys}')
+
+    return tuple(
+        (registry.unit_for_price_key(price_key), cast(Decimal | TieredPrices, value))
+        for price_key, value in stored_prices
+    )
+
+
 def _model_price_uses_tiered_prices(model_price: ModelPrice, registry: UnitRegistry) -> bool:
     return any(
         isinstance(getattr(model_price, price_key), TieredPrices)

--- a/packages/python/genai_prices/units.py
+++ b/packages/python/genai_prices/units.py
@@ -19,6 +19,10 @@ class UnitDef:
 
 class UnitRegistry:
     units: dict[str, UnitDef]
+    all_usage_keys: frozenset[str]
+    all_price_keys: frozenset[str]
+    reported_usage_keys: frozenset[str]
+    reported_usage_keys_in_order: tuple[str, ...]
     _units_by_price_key: dict[str, UnitDef]
     _units_by_dimension: dict[frozenset[tuple[str, str]], UnitDef]
     _ancestor_usage_keys: dict[str, frozenset[str]]
@@ -52,13 +56,14 @@ class UnitRegistry:
                 if maybe_ancestor is not unit and _is_dimension_subset(maybe_ancestor, unit)
             )
 
+        self.all_usage_keys = frozenset(self.units)
+        self.all_price_keys = frozenset(self._units_by_price_key)
+        self.reported_usage_keys_in_order = tuple(usage_key for usage_key in self.units if usage_key != 'requests')
+        self.reported_usage_keys = frozenset(self.reported_usage_keys_in_order)
+
     def unit_for_price_key(self, price_key: str) -> UnitDef:
         """Return the registered unit priced by price_key."""
         return self._units_by_price_key[price_key]
-
-    def reported_usage_keys(self) -> frozenset[str]:
-        """Return registered keys callers may report, excluding the pricing-only requests unit."""
-        return frozenset(usage_key for usage_key in self.units if usage_key != 'requests')
 
     def ancestor_usage_keys(self, usage_key: str) -> frozenset[str]:
         return self._ancestor_usage_keys[usage_key]

--- a/packages/python/genai_prices/validation.py
+++ b/packages/python/genai_prices/validation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Collection
+
 from genai_prices.units import UnitDef, UnitRegistry
 
 
@@ -21,8 +23,16 @@ def validate_ancestor_coverage(priced_usage_keys: set[str], registry: UnitRegist
 def validate_join_coverage(priced_usage_keys: set[str], registry: UnitRegistry) -> None:
     priced_units = _priced_units(priced_usage_keys, registry)
 
-    for index, first_unit in enumerate(priced_units):
-        for second_unit in priced_units[index + 1 :]:
+    _validate_join_coverage_units(priced_units, priced_usage_keys, registry)
+
+
+def _validate_join_coverage_units(
+    priced_units: Collection[UnitDef], priced_usage_keys: set[str], registry: UnitRegistry
+) -> None:
+    ordered_priced_units = sorted(priced_units, key=lambda unit: unit.usage_key)
+
+    for index, first_unit in enumerate(ordered_priced_units):
+        for second_unit in ordered_priced_units[index + 1 :]:
             if not first_unit.is_compatible_with(second_unit):
                 continue
 
@@ -43,11 +53,28 @@ def _priced_units(priced_usage_keys: set[str], registry: UnitRegistry) -> list[U
 
 
 def validate_model_price(price_keys: set[str], registry: UnitRegistry) -> None:
-    validate_price_keys(price_keys, registry)
+    priced_units: list[UnitDef] = []
+    unknown_price_keys: set[str] = set()
+    for price_key in price_keys:
+        unit = _unit_for_price_key(price_key, registry)
+        if unit is None:
+            unknown_price_keys.add(price_key)
+        else:
+            priced_units.append(unit)
 
-    priced_usage_keys = {registry.unit_for_price_key(price_key).usage_key for price_key in price_keys}
+    if unknown_price_keys:
+        bad_keys = ', '.join(sorted(unknown_price_keys))
+        raise ValueError(f'Unknown price key: {bad_keys}')
+
+    validate_priced_units(priced_units, registry)
+
+
+def validate_priced_units(priced_units: Collection[UnitDef], registry: UnitRegistry) -> None:
+    """Validate ancestor and join coverage for already-resolved priced units."""
+    priced_usage_keys = {unit.usage_key for unit in priced_units}
+
     validate_ancestor_coverage(priced_usage_keys, registry)
-    validate_join_coverage(priced_usage_keys, registry)
+    _validate_join_coverage_units(priced_units, priced_usage_keys, registry)
 
 
 def validate_extractor_destinations(dest_keys: set[str], reported_usage_keys: set[str] | frozenset[str]) -> None:

--- a/prices/src/prices/build.py
+++ b/prices/src/prices/build.py
@@ -84,7 +84,7 @@ def _add_unit_vocabulary_to_schema(json_schema: dict[str, Any], raw_units: dict[
     extractor_mapping_schema = cast(dict[str, Any], json_schema['$defs']['UsageExtractorMapping'])
     extractor_mapping_properties = cast(dict[str, Any], extractor_mapping_schema['properties'])
     dest_schema = cast(dict[str, Any], extractor_mapping_properties['dest'])
-    dest_schema['enum'] = sorted(registry.reported_usage_keys())
+    dest_schema['enum'] = sorted(registry.reported_usage_keys)
 
     return json_schema
 

--- a/prices/src/prices/package_data.py
+++ b/prices/src/prices/package_data.py
@@ -126,7 +126,7 @@ def validate_provider_model_prices(providers: Iterable[object], registry: UnitRe
 def validate_provider_extractor_destinations(providers: Iterable[object], registry: UnitRegistry) -> None:
     from genai_prices.validation import validate_extractor_destinations
 
-    reported_usage_keys = registry.reported_usage_keys()
+    reported_usage_keys = registry.reported_usage_keys
     for provider in providers:
         provider_id = cast(str, getattr(provider, 'id'))
         extractors = getattr(provider, 'extractors', None)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -184,6 +184,8 @@ def test_unit_registry_constructs_current_units() -> None:
 
     assert set(registry.units) == TOKEN_USAGE_KEYS | {'requests'}
     assert len(registry.units) == 21
+    assert registry.all_usage_keys == frozenset(TOKEN_USAGE_KEYS | {'requests'})
+    assert registry.all_price_keys == frozenset(TOKEN_PRICE_KEYS | {'requests_kcount'})
     assert registry.unit_for_price_key('input_mtok') is registry.units['input_tokens']
     assert registry.unit_for_price_key('cache_image_write_mtok').usage_key == 'cache_image_write_tokens'
     assert registry.unit_for_price_key('requests_kcount') is registry.units['requests']
@@ -296,13 +298,26 @@ def test_unit_registry_join_lookup_returns_registered_cache_write_overlap() -> N
 def test_unit_registry_reported_usage_keys_include_public_token_keys() -> None:
     registry = UnitRegistry(load_units())
 
-    assert registry.reported_usage_keys() == frozenset(TOKEN_USAGE_KEYS)
+    assert registry.reported_usage_keys == frozenset(TOKEN_USAGE_KEYS)
 
 
 def test_unit_registry_reported_usage_keys_exclude_pricing_only_requests() -> None:
     registry = UnitRegistry(load_units())
 
-    assert 'requests' not in registry.reported_usage_keys()
+    assert 'requests' not in registry.reported_usage_keys
+
+
+def test_unit_registry_key_indexes_are_immutable_and_reused() -> None:
+    raw_units = load_units()
+    registry = UnitRegistry(raw_units)
+
+    assert isinstance(registry.all_usage_keys, frozenset)
+    assert isinstance(registry.all_price_keys, frozenset)
+    assert isinstance(registry.reported_usage_keys, frozenset)
+    assert isinstance(registry.reported_usage_keys_in_order, tuple)
+    assert registry.reported_usage_keys_in_order == tuple(key for key in raw_units if key != 'requests')
+    assert registry.reported_usage_keys is registry.reported_usage_keys
+    assert registry.reported_usage_keys_in_order is registry.reported_usage_keys_in_order
 
 
 def test_validate_units_rejects_missing_family_dimension() -> None:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -714,17 +714,19 @@ def test_collect_resolved_model_prices_excludes_subclass_only_state() -> None:
 
 def test_compute_registry_priced_counts_handles_parent_child_token_counts() -> None:
     registry = UnitRegistry(load_units())
-    units = _collect_model_price_units(ModelPrice(input_mtok=Decimal('1'), cache_read_mtok=Decimal('2')), registry)
+    resolved_prices = _collect_resolved_model_prices(
+        ModelPrice(input_mtok=Decimal('1'), cache_read_mtok=Decimal('2')), registry
+    )
 
     assert _compute_registry_priced_counts(
-        units,
+        resolved_prices,
         Usage(input_tokens=1_000, cache_read_tokens=250),
     ) == {'cache_read_tokens': 250, 'input_tokens': 750}
 
 
 def test_compute_registry_priced_counts_handles_cached_audio_overlap() -> None:
     registry = UnitRegistry(load_units())
-    units = _collect_model_price_units(
+    resolved_prices = _collect_resolved_model_prices(
         ModelPrice(
             input_mtok=Decimal('1'),
             cache_read_mtok=Decimal('2'),
@@ -735,7 +737,7 @@ def test_compute_registry_priced_counts_handles_cached_audio_overlap() -> None:
     )
 
     assert _compute_registry_priced_counts(
-        units,
+        resolved_prices,
         Usage(
             input_tokens=1_000,
             cache_read_tokens=400,
@@ -752,16 +754,34 @@ def test_compute_registry_priced_counts_handles_cached_audio_overlap() -> None:
 
 def test_compute_registry_priced_counts_handles_one_request_count() -> None:
     registry = UnitRegistry(load_units())
-    units = _collect_model_price_units(ModelPrice(requests_kcount=Decimal('1')), registry)
+    resolved_prices = _collect_resolved_model_prices(ModelPrice(requests_kcount=Decimal('1')), registry)
 
-    assert _compute_registry_priced_counts(units, Usage()) == {'requests': 1}
+    assert _compute_registry_priced_counts(resolved_prices, Usage()) == {'requests': 1}
 
 
 def test_compute_registry_priced_counts_does_not_add_token_counts_for_request_only_prices() -> None:
     registry = UnitRegistry(load_units())
-    units = _collect_model_price_units(ModelPrice(requests_kcount=Decimal('1')), registry)
+    resolved_prices = _collect_resolved_model_prices(ModelPrice(requests_kcount=Decimal('1')), registry)
 
-    assert set(_compute_registry_priced_counts(units, Usage(input_tokens=100))) == {'requests'}
+    assert set(_compute_registry_priced_counts(resolved_prices, Usage(input_tokens=100))) == {'requests'}
+
+
+def test_model_price_calculation_does_not_use_registry_scanning_collectors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from genai_prices import types as runtime_types
+
+    def fail(*_args: object) -> None:
+        pytest.fail('standard calculation used a registry-scanning collector')
+
+    monkeypatch.setattr(runtime_types, '_collect_effective_model_price_keys', fail)
+    monkeypatch.setattr(runtime_types, '_collect_model_price_units', fail)
+
+    assert ModelPrice(input_mtok=Decimal('2')).calc_price(Usage(input_tokens=1_000_000)) == {
+        'input_price': Decimal('2'),
+        'output_price': Decimal('0'),
+        'total_price': Decimal('2'),
+    }
 
 
 def test_build_loads_units() -> None:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -10,7 +10,7 @@ from dataclasses import fields
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -771,17 +771,18 @@ def test_model_price_calculation_does_not_use_registry_scanning_collectors(
 ) -> None:
     from genai_prices import types as runtime_types
 
-    def fail(*_args: object) -> None:
-        pytest.fail('standard calculation used a registry-scanning collector')
-
-    monkeypatch.setattr(runtime_types, '_collect_effective_model_price_keys', fail)
-    monkeypatch.setattr(runtime_types, '_collect_model_price_units', fail)
+    collect_effective_keys = Mock(side_effect=AssertionError('standard calculation scanned effective price keys'))
+    collect_model_price_units = Mock(side_effect=AssertionError('standard calculation scanned model price units'))
+    monkeypatch.setattr(runtime_types, '_collect_effective_model_price_keys', collect_effective_keys)
+    monkeypatch.setattr(runtime_types, '_collect_model_price_units', collect_model_price_units)
 
     assert ModelPrice(input_mtok=Decimal('2')).calc_price(Usage(input_tokens=1_000_000)) == {
         'input_price': Decimal('2'),
         'output_price': Decimal('0'),
         'total_price': Decimal('2'),
     }
+    collect_effective_keys.assert_not_called()
+    collect_model_price_units.assert_not_called()
 
 
 def test_build_loads_units() -> None:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -21,9 +21,11 @@ from genai_prices.types import (
     ModelInfo,
     ModelPrice,
     Provider,
+    TieredPrices,
     Usage,
     _collect_effective_model_price_keys,
     _collect_model_price_units,
+    _collect_resolved_model_prices,
     _compute_registry_priced_counts,
 )
 from genai_prices.units import UnitRegistry, _get_registry
@@ -627,6 +629,87 @@ def test_collect_model_price_units_handles_registered_custom_fields() -> None:
     units = _collect_model_price_units(CustomModelPrice(input_mtok=Decimal('1'), sausage_mtok=Decimal('2')), registry)
 
     assert {unit.usage_key for unit in units} == {'input_tokens', 'sausage_tokens'}
+
+
+def test_collect_resolved_model_prices_handles_empty_price() -> None:
+    registry = UnitRegistry(load_units())
+
+    assert _collect_resolved_model_prices(ModelPrice(), registry) == ()
+
+
+def test_collect_resolved_model_prices_retains_units_and_current_values() -> None:
+    registry = UnitRegistry(load_units())
+
+    resolved_prices = _collect_resolved_model_prices(
+        ModelPrice(input_mtok=Decimal('1'), output_mtok=Decimal('2')),
+        registry,
+    )
+
+    assert resolved_prices == (
+        (registry.units['input_tokens'], Decimal('1')),
+        (registry.units['output_tokens'], Decimal('2')),
+    )
+
+
+def test_collect_resolved_model_prices_handles_dynamic_registered_price() -> None:
+    registry = UnitRegistry(load_units())
+
+    assert _collect_resolved_model_prices(ModelPrice(cache_image_read_mtok=Decimal('0.5')), registry) == (
+        (registry.units['cache_image_read_tokens'], Decimal('0.5')),
+    )
+
+
+def test_collect_resolved_model_prices_ignores_none_values() -> None:
+    registry = UnitRegistry(load_units())
+
+    assert _collect_resolved_model_prices(ModelPrice(input_mtok=None), registry) == ()
+
+
+def test_collect_resolved_model_prices_rejects_unknown_base_price() -> None:
+    registry = UnitRegistry(load_units())
+
+    with pytest.raises(ValueError, match='Unknown price key: hovercraft_mtok'):
+        _collect_resolved_model_prices(ModelPrice(hovercraft_mtok=Decimal('1')), registry)
+
+
+def test_collect_resolved_model_prices_handles_request_price() -> None:
+    registry = UnitRegistry(load_units())
+
+    assert _collect_resolved_model_prices(ModelPrice(requests_kcount=Decimal('3')), registry) == (
+        (registry.units['requests'], Decimal('3')),
+    )
+
+
+def test_collect_resolved_model_prices_retains_tiered_price() -> None:
+    registry = UnitRegistry(load_units())
+    tiered_price = TieredPrices(base=Decimal('1'), tiers=[])
+
+    assert _collect_resolved_model_prices(ModelPrice(input_mtok=tiered_price), registry) == (
+        (registry.units['input_tokens'], tiered_price),
+    )
+
+
+def test_collect_resolved_model_prices_includes_registered_subclass_price() -> None:
+    registry = _custom_price_key_registry()
+
+    class CustomModelPrice(ModelPrice):
+        pass
+
+    assert _collect_resolved_model_prices(CustomModelPrice(sausage_mtok=Decimal('2')), registry) == (
+        (registry.units['sausage_tokens'], Decimal('2')),
+    )
+
+
+def test_collect_resolved_model_prices_excludes_subclass_only_state() -> None:
+    registry = UnitRegistry(load_units())
+
+    class CustomModelPrice(ModelPrice):
+        pass
+
+    assert _collect_resolved_model_prices(
+        CustomModelPrice(input_mtok=Decimal('1'), sausage_price=Decimal('2')),
+        registry,
+    ) == ((registry.units['input_tokens'], Decimal('1')),)
 
 
 def test_compute_registry_priced_counts_handles_parent_child_token_counts() -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -11,6 +11,7 @@ from genai_prices.validation import (
     validate_join_coverage,
     validate_model_price,
     validate_price_keys,
+    validate_priced_units,
 )
 
 from .unit_registry_helpers import load_units
@@ -143,6 +144,80 @@ def test_validate_model_price_rejects_missing_join_units() -> None:
         match='Missing registered join unit for priced units cache_write_tokens and input_audio_tokens',
     ):
         validate_model_price({'input_mtok', 'cache_write_mtok', 'input_audio_mtok'}, registry)
+
+
+def test_validate_priced_units_accepts_valid_units() -> None:
+    registry = UnitRegistry(load_units())
+
+    validate_priced_units(
+        [
+            registry.units['input_tokens'],
+            registry.units['cache_read_tokens'],
+            registry.units['requests'],
+        ],
+        registry,
+    )
+
+
+def test_validate_priced_units_rejects_missing_ancestor() -> None:
+    registry = UnitRegistry(load_units())
+
+    with pytest.raises(ValueError, match='Missing ancestor price for cache_read_tokens: input_tokens'):
+        validate_priced_units([registry.units['cache_read_tokens']], registry)
+
+
+def test_validate_priced_units_rejects_missing_join() -> None:
+    registry = UnitRegistry(load_units())
+    priced_units = [
+        registry.units['input_tokens'],
+        registry.units['cache_read_tokens'],
+        registry.units['input_audio_tokens'],
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match='Missing join price for cache_read_tokens and input_audio_tokens: cache_audio_read_tokens',
+    ):
+        validate_priced_units(priced_units, registry)
+
+
+def test_validate_priced_units_accepts_request_only() -> None:
+    registry = UnitRegistry(load_units())
+
+    validate_priced_units([registry.units['requests']], registry)
+
+
+def test_validate_priced_units_accepts_explicit_custom_registry_units() -> None:
+    registry = UnitRegistry(
+        {
+            'characters': {
+                'per': 1_000,
+                'price_key': 'characters_kcount',
+                'dimensions': {'family': 'characters'},
+            }
+        }
+    )
+
+    validate_priced_units([registry.units['characters']], registry)
+
+
+@pytest.mark.parametrize(
+    'price_keys',
+    [
+        {'cache_read_mtok'},
+        {'input_mtok', 'cache_read_mtok', 'input_audio_mtok'},
+    ],
+)
+def test_resolved_and_key_model_price_validation_errors_match(price_keys: set[str]) -> None:
+    registry = UnitRegistry(load_units())
+    priced_units = [registry.unit_for_price_key(price_key) for price_key in price_keys]
+
+    with pytest.raises(ValueError) as key_error:
+        validate_model_price(price_keys, registry)
+    with pytest.raises(ValueError) as unit_error:
+        validate_priced_units(priced_units, registry)
+
+    assert str(unit_error.value) == str(key_error.value)
 
 
 def test_bundled_provider_model_prices_pass_registry_validation() -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -172,7 +172,7 @@ def test_validate_extractor_destinations_accepts_current_reported_usage_keys() -
 
     validate_extractor_destinations(
         {'input_tokens', 'cache_read_tokens', 'cache_audio_read_tokens'},
-        registry.reported_usage_keys(),
+        registry.reported_usage_keys,
     )
 
 
@@ -180,18 +180,18 @@ def test_validate_extractor_destinations_rejects_price_keys() -> None:
     registry = UnitRegistry(load_units())
 
     with pytest.raises(ValueError, match='Invalid extractor destination: input_mtok'):
-        validate_extractor_destinations({'input_mtok'}, registry.reported_usage_keys())
+        validate_extractor_destinations({'input_mtok'}, registry.reported_usage_keys)
 
 
 def test_validate_extractor_destinations_rejects_unknown_strings() -> None:
     registry = UnitRegistry(load_units())
 
     with pytest.raises(ValueError, match='Invalid extractor destination: imaginary_tokens'):
-        validate_extractor_destinations({'imaginary_tokens'}, registry.reported_usage_keys())
+        validate_extractor_destinations({'imaginary_tokens'}, registry.reported_usage_keys)
 
 
 def test_validate_extractor_destinations_rejects_pricing_only_requests() -> None:
     registry = UnitRegistry(load_units())
 
     with pytest.raises(ValueError, match='Invalid extractor destination: requests'):
-        validate_extractor_destinations({'requests'}, registry.reported_usage_keys())
+        validate_extractor_destinations({'requests'}, registry.reported_usage_keys)


### PR DESCRIPTION
## Summary

- precompute immutable Python registry key indexes instead of rebuilding key collections
- validate already-resolved priced units in Python and JavaScript
- collect each model price and its unit once per calculation, then reuse it for validation, decomposition, tier detection, and aggregation
- preserve request pricing, tiered pricing, custom Python subclasses, custom JavaScript objects, explicit registries, and existing error semantics

## Stack

This PR is stacked on #351 (`codex/data-driven-unit-registry-spec`) and contains only the residual Phase 1 stateless hot-path cleanup.

## Validation

- `make lint typecheck`
- `uv run pytest` — 760 passed, 41 xfailed
- `npm run test --workspace=packages/js` — 733 passed, 1 skipped
- `npm run build --workspace=packages/js`
