### PR TITLE
Add upper bound to uv_build requirement

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.8.10"]
+requires = ["uv_build>=0.8.10,<0.12"]
 build-backend = "uv_build"
 
 [project]


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

`uv sync` warns that `packages/python/pyproject.toml` pins `uv_build>=0.8.10` with no upper bound, which would break source distributions when a future breaking `uv_build` version ships. Added the `<0.12` bound uv suggests (current uv is 0.11.x), matching the bounded style already used in `prices/pyproject.toml`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

