### PR TITLE
Ignore generated price JSON in reviews

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
+
+prices/data.json linguist-generated=true
+prices/data_slim.json linguist-generated=true


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

Marks `prices/data.json` and `prices/data_slim.json` as `linguist-generated` in `.gitattributes`.

Cubic skips files with this attribute, keeping reviews focused on the provider YAML source rather than generated one-line JSON artifacts. GitHub will also collapse these files by default.

Validation: `git check-attr` confirms both files are generated; `git diff --check` passes.

Cubic documentation: https://docs.cubic.dev/ai-review/ai-review-settings#exclude-generated-files


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

