### PR TITLE
Skill: require covering every provider that hosts a model

### DIFF
--- a/.claude/skills/add-price-model/SKILL.md
+++ b/.claude/skills/add-price-model/SKILL.md
@@ -12,6 +12,26 @@ description: >-
 Never edit `prices/data.json` / `prices/data_slim.json` by hand — they are generated. Edit the
 provider YAML in `prices/providers/<provider>.yml`, then `make build-prices`.
 
+## 0. Scope: every provider that hosts this model, not just the one you were named
+
+A model rarely lives on one provider. The big vendors' flagships are resold across clouds and
+aggregators, and each needs **its own YAML entry** — the same request "add the new Claude" means
+`anthropic.yml` **and** `aws.yml` (Bedrock) **and** `google.yml` (Vertex) **and** `openrouter.yml`.
+Adding only the direct-vendor entry is the most common miss (it's what happened for Opus 5 in #501,
+requiring the follow-up #502). Before editing, list every provider that hosts the model and cover
+them in one PR:
+
+- **Direct vendor** — `anthropic.yml`, `openai.yml`, `google.yml` (Gemini), `x_ai.yml`, etc.
+- **Aggregators/gateways** — `openrouter.yml` (usually day-one; often exposes `-fast`/`:beta` variants).
+- **Cloud resellers** — `aws.yml` (Bedrock: `global.*` + `regional.*` split, regional ~+10%),
+  `google.yml` (Vertex Claude entries live here too, separate from Gemini), Azure (`azure.yml` is
+  Azure **OpenAI** only — Claude on Foundry is out of scope there; note it, don't force it).
+
+Confirm hosting from each provider's docs/model list; don't assume. If a reseller genuinely hasn't
+shipped it yet, that's the **only** reason to defer a provider — say which one and why in the PR, and
+follow up when it lands (see "Provider rollout timing" below). "I was only asked about provider X" is
+not a reason to skip the others.
+
 ## 1. Branch
 
 Contribute via a branch on `origin` (this repo is `pydantic/genai-prices`, no fork). Always base off
@@ -135,5 +155,7 @@ addressed or dismissed (see `AGENTS.md`). Unresolved review threads mean the PR 
 
 ## Provider rollout timing
 
-OpenRouter usually lists new models day-one — add them in the same PR. Bedrock / Vertex lag; poll and
-follow up in a later PR rather than blocking.
+This is the escape hatch for step 0, not a reason to default to a single-provider PR. Cover every
+provider that already hosts the model in the same PR. OpenRouter usually lists new models day-one.
+Only when a reseller (Bedrock / Vertex) genuinely hasn't shipped yet do you defer _that_ provider —
+name it in the PR body and follow up in a later PR once it lands, rather than blocking the rest.


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David. David gave this a light review.

## Why

#501 added Claude Opus 5 to `anthropic.yml` only; it's also on Bedrock, Vertex and OpenRouter, which needed the follow-up #502. The `add-price-model` skill's cross-provider guidance was buried in a tail "Provider rollout timing" note that read as optional, so a single-provider PR looked complete.

## Change

`.claude/skills/add-price-model/SKILL.md`:

- New **`## 0. Scope: every provider that hosts this model`** step up front — makes "add the new Claude = `anthropic.yml` + `aws.yml` + `google.yml` + `openrouter.yml`" a required scoping decision, cites the #501→#502 miss, and lists the direct-vendor / aggregator / cloud-reseller buckets (incl. the Azure-is-OpenAI-only caveat).
- Rewrote the tail **Provider rollout timing** note into an explicit escape hatch for step 0 (defer only a reseller that genuinely hasn't shipped, and name it) rather than the sole mention.

Docs-only; no code or price data touched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

