### PR TITLE
Honor timezone-aware price intervals in JavaScript

### DIFF
--- a/packages/js/src/__tests__/calcPrice.test.ts
+++ b/packages/js/src/__tests__/calcPrice.test.ts
@@ -1,14 +1,71 @@
 import { describe, expect, it } from 'vitest'
 
-import type { ModelPrice, Usage } from '../types'
+import type { ModelInfo, ModelPrice, Usage } from '../types'
 
-import { calcPrice } from '../engine'
+import { calcPrice, getActiveModelPrice } from '../engine'
 
 const MILLION = 1_000_000
 
 function mtok(rate: number, tokens: number): number {
   return (rate * tokens) / MILLION
 }
+
+describe('getActiveModelPrice', () => {
+  it('uses timezone-aware half-open daily constraints', () => {
+    const offPeak = { input_mtok: 1 }
+    const standard = { input_mtok: 2 }
+    const model: ModelInfo = {
+      id: 'conditional',
+      match: { equals: 'conditional' },
+      prices: [
+        { prices: offPeak },
+        {
+          constraint: {
+            end_time: '16:30:00Z',
+            start_time: '01:30:00+01:00',
+            type: 'time_of_date',
+          },
+          prices: standard,
+        },
+      ],
+    }
+
+    expect(getActiveModelPrice(model, new Date('2025-01-01T00:29:59.999Z'))).toBe(offPeak)
+    expect(getActiveModelPrice(model, new Date('2025-01-01T00:30:00.000Z'))).toBe(standard)
+    expect(getActiveModelPrice(model, new Date('2025-01-01T16:29:59.999Z'))).toBe(standard)
+    expect(getActiveModelPrice(model, new Date('2025-01-01T16:30:00.000Z'))).toBe(offPeak)
+  })
+
+  it('rejects malformed time constraints', () => {
+    const model: ModelInfo = {
+      id: 'conditional',
+      match: { equals: 'conditional' },
+      prices: [
+        { prices: { input_mtok: 1 } },
+        {
+          constraint: {
+            end_time: '16:30:00Z',
+            start_time: '25:00:00Z',
+            type: 'time_of_date',
+          },
+          prices: { input_mtok: 2 },
+        },
+      ],
+    }
+
+    expect(() => getActiveModelPrice(model, new Date('2025-01-01T12:00:00Z'))).toThrow('Invalid time-of-day constraint: 25:00:00Z')
+  })
+
+  it('rejects an invalid timestamp for conditional prices', () => {
+    const model: ModelInfo = {
+      id: 'conditional',
+      match: { equals: 'conditional' },
+      prices: [{ prices: { input_mtok: 1 } }],
+    }
+
+    expect(() => getActiveModelPrice(model, new Date(Number.NaN))).toThrow(new RangeError('Invalid time value'))
+  })
+})
 
 describe('Core Price Calculation Function', () => {
   describe('calcPrice with separated input/output prices', () => {

--- a/packages/js/src/engine.ts
+++ b/packages/js/src/engine.ts
@@ -1,3 +1,4 @@
+import { utcTimeOfDaySeconds } from './timeOfDay'
 import { MatchLogic, ModelInfo, ModelPrice, ModelPriceCalculationResult, Provider, ProviderFindOptions, TieredPrices, Usage } from './types'
 
 /**
@@ -120,6 +121,9 @@ export function getActiveModelPrice(model: ModelInfo, timestamp: Date): ModelPri
   if (!Array.isArray(model.prices)) {
     return model.prices
   }
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new RangeError('Invalid time value')
+  }
   // Conditional prices: last active wins
   for (let i = model.prices.length - 1; i >= 0; i--) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -135,20 +139,23 @@ export function getActiveModelPrice(model: ModelInfo, timestamp: Date): ModelPri
         return cond.prices
       }
     } else {
-      // Extract UTC time to match constraint times which are in UTC (with 'Z' suffix)
-      const t = timestamp.toISOString().slice(11, 19) // Get "HH:MM:SS" from ISO string
-      const startTime = constraint.start_time
-      const endTime = constraint.end_time
+      const time =
+        timestamp.getUTCHours() * 3_600 +
+        timestamp.getUTCMinutes() * 60 +
+        timestamp.getUTCSeconds() +
+        timestamp.getUTCMilliseconds() / 1_000
+      const startTime = utcTimeOfDaySeconds(constraint.start_time)
+      const endTime = utcTimeOfDaySeconds(constraint.end_time)
 
       // Handle time ranges that span midnight (end time < start time)
       if (endTime < startTime) {
         // Time is in range if it's >= start OR < end
-        if (t >= startTime || t < endTime) {
+        if (time >= startTime || time < endTime) {
           return cond.prices
         }
       } else {
         // Normal time range (start <= time < end)
-        if (t >= startTime && t < endTime) {
+        if (time >= startTime && time < endTime) {
           return cond.prices
         }
       }

--- a/packages/js/src/timeOfDay.ts
+++ b/packages/js/src/timeOfDay.ts
@@ -1,0 +1,17 @@
+export function utcTimeOfDaySeconds(value: string): number {
+  const match = /^(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|([+-])(\d{2}):(\d{2}))$/.exec(value)
+  if (!match) throw new Error(`Invalid time-of-day constraint: ${value}`)
+
+  const [, hoursString, minutesString, secondsString, fraction = '', timezone, sign, offsetHours = '00', offsetMinutes = '00'] = match
+  const hours = Number(hoursString)
+  const minutes = Number(minutesString)
+  const seconds = Number(secondsString)
+  const offset = (Number(offsetHours) * 60 + Number(offsetMinutes)) * 60
+  if (hours > 23 || minutes > 59 || seconds > 59 || offsetHours > '23' || offsetMinutes > '59') {
+    throw new Error(`Invalid time-of-day constraint: ${value}`)
+  }
+
+  const localSeconds = hours * 3_600 + minutes * 60 + seconds + Number(`0.${fraction}`)
+  const signedOffset = timezone === 'Z' ? 0 : sign === '+' ? offset : -offset
+  return (localSeconds - signedOffset + 86_400) % 86_400
+}

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -46,8 +46,8 @@ export interface StartDateConstraint {
 }
 
 export interface TimeOfDateConstraint {
-  end_time: string // HH:MM:SS
-  start_time: string // HH:MM:SS
+  end_time: string // HH:MM:SS[.fraction](Z|±HH:MM)
+  start_time: string // HH:MM:SS[.fraction](Z|±HH:MM)
   type: 'time_of_date'
 }
 


### PR DESCRIPTION
## What changed

- Parse timezone-aware daily price constraints before comparing them with UTC timestamps.
- Preserve half-open interval boundaries, including fractional seconds and UTC offsets.
- Reject malformed constraint times and invalid `Date` inputs explicitly.
- Document the accepted TypeScript time shape.

## Why

The published provider schema uses JSON Schema `format: time`, and Python already requires timezone-aware values. JavaScript compared raw strings instead, which only worked reliably for a narrow `HH:MM:SSZ` representation and mishandled offsets and exact boundaries.

This is ordinary conditional-pricing correctness, independent of the data-driven unit registry work, so it is split beneath the Phase 1 and Phase 2 PRs.

## Validation

- `npm run ci` — 634 passed, 1 skipped
- `npm run typecheck`
- Prettier check and pre-commit hooks
- ESLint completed with one pre-existing unused-disable warning in `engine.ts`
