### PR TITLE
fix: validate Python pricing inputs

### DIFF
--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import InitVar, dataclass, field
 from datetime import date, datetime, time, timezone
 from decimal import Decimal
+from numbers import Integral
 from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeGuard, TypeVar, cast, overload
 
 import pydantic
@@ -331,9 +332,9 @@ class Usage:
 
 
 def _validate_usage_value(usage_key: str, value: object) -> int:
-    if type(value) is not int or value < 0:
+    if isinstance(value, bool) or not isinstance(value, Integral) or value < 0:
         raise ValueError(f'Invalid usage value for {usage_key}: expected a non-negative integer')
-    return value
+    return int(value)
 
 
 def _reported_overlap_keys_for_join(

--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -213,6 +213,7 @@ class Usage:
     @classmethod
     def from_raw(cls, obj: object) -> Usage:
         if isinstance(obj, Usage):
+            obj._reported_values()
             return obj
 
         values: dict[str, int] = {}
@@ -236,15 +237,20 @@ class Usage:
         raise AttributeError(f'{type(self).__name__!r} object has no attribute {name!r}')
 
     def _store_values(self, values: Mapping[str, int | None]) -> None:
+        reported_usage_keys = _reported_usage_keys()
         for key, value in values.items():
             if value is None:
                 self.__dict__.pop(key, None)
+            elif key in reported_usage_keys:
+                self.__dict__[key] = _validate_usage_value(key, value)
             else:
                 self.__dict__[key] = value
 
     def _reported_values(self) -> dict[str, int]:
         reported_usage_keys = _reported_usage_keys()
-        return {key: cast(int, value) for key, value in self.__dict__.items() if key in reported_usage_keys}
+        return {
+            key: _validate_usage_value(key, value) for key, value in self.__dict__.items() if key in reported_usage_keys
+        }
 
     def reported_value(self, usage_key: str) -> int:
         return self._reported_values().get(usage_key, 0)
@@ -322,6 +328,12 @@ class Usage:
             f'Missing usage for {usage_key}: reported descendant usage keys {reported_keys} '
             f'require explicit {usage_key}'
         )
+
+
+def _validate_usage_value(usage_key: str, value: object) -> int:
+    if type(value) is not int or value < 0:
+        raise ValueError(f'Invalid usage value for {usage_key}: expected a non-negative integer')
+    return value
 
 
 def _reported_overlap_keys_for_join(

--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -854,10 +854,37 @@ def _collect_resolved_model_prices(
         )
 
     return tuple(
-        (registry.unit_for_price_key(price_key), cast(Decimal | TieredPrices, value))
+        (registry.unit_for_price_key(price_key), _validate_model_price_value(price_key, value))
         for price_key, value in stored_prices
         if price_key not in unknown_price_keys
     )
+
+
+def _validate_model_price_value(price_key: str, value: object) -> Decimal | TieredPrices:
+    if _is_valid_price_decimal(value):
+        return value
+    if isinstance(value, TieredPrices):
+        previous_start = -1
+        for tier in value.tiers:
+            if (
+                type(tier.start) is not int
+                or tier.start < 0
+                or tier.start < previous_start
+                or not _is_valid_price_decimal(tier.price)
+            ):
+                break
+            previous_start = tier.start
+        else:
+            if _is_valid_price_decimal(value.base):
+                return value
+
+    raise ValueError(
+        f'Invalid price value for {price_key}: expected a finite non-negative Decimal or valid tiered prices'
+    )
+
+
+def _is_valid_price_decimal(value: object) -> TypeGuard[Decimal]:
+    return isinstance(value, Decimal) and value.is_finite() and value >= 0
 
 
 def _compute_registry_priced_counts(

--- a/tests/test_price_calc.py
+++ b/tests/test_price_calc.py
@@ -311,7 +311,7 @@ def test_model_price_str_requests_and_private_state() -> None:
 
 
 def test_calc_price_warns_and_ignores_unregistered_dynamic_extra() -> None:
-    price = ModelPrice(hovercraft_mtok=Decimal('1'))
+    price = ModelPrice(hovercraft_mtok=Decimal('NaN'))
 
     with pytest.warns(UserWarning, match='Unsupported price key for standard pricing: hovercraft_mtok'):
         result = price.calc_price(Usage(input_tokens=1))
@@ -321,6 +321,33 @@ def test_calc_price_warns_and_ignores_unregistered_dynamic_extra() -> None:
         'output_price': Decimal(0),
         'total_price': Decimal(0),
     }
+
+
+@pytest.mark.parametrize('price', [Decimal('-1'), Decimal('NaN'), Decimal('Infinity')])
+def test_calc_price_rejects_invalid_recognized_flat_price(price: Decimal) -> None:
+    with pytest.raises(
+        ValueError,
+        match='Invalid price value for input_mtok: expected a finite non-negative Decimal or valid tiered prices',
+    ):
+        ModelPrice(input_mtok=price).calc_price(Usage(input_tokens=1))
+
+
+@pytest.mark.parametrize(
+    'price',
+    [
+        TieredPrices(base=Decimal('-1'), tiers=[]),
+        TieredPrices(base=Decimal('NaN'), tiers=[]),
+        TieredPrices(base=Decimal('1'), tiers=[Tier(start=-1, price=Decimal('2'))]),
+        TieredPrices(base=Decimal('1'), tiers=[Tier(start=100, price=Decimal('-2'))]),
+        TieredPrices(base=Decimal('1'), tiers=[Tier(start=100, price=Decimal('Infinity'))]),
+    ],
+)
+def test_calc_price_rejects_invalid_recognized_tiered_price(price: TieredPrices) -> None:
+    with pytest.raises(
+        ValueError,
+        match='Invalid price value for input_mtok: expected a finite non-negative Decimal or valid tiered prices',
+    ):
+        ModelPrice(input_mtok=price).calc_price(Usage(input_tokens=1))
 
 
 def test_calc_price_rejects_dynamic_descendant_without_ancestors() -> None:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -28,6 +28,12 @@ def test_usage_direct_construction_is_strict_for_reported_usage_keys() -> None:
     assert usage.output_tokens == 0
 
 
+@pytest.mark.parametrize('value', [-1, 1.5, float('NaN'), float('Infinity'), True])
+def test_usage_direct_construction_rejects_invalid_reported_values(value: Any) -> None:
+    with pytest.raises(ValueError, match='Invalid usage value for input_tokens: expected a non-negative integer'):
+        Usage(input_tokens=value)
+
+
 def test_usage_direct_construction_warns_for_unknown_keywords() -> None:
     with pytest.warns(UserWarning, match='Unsupported usage key for standard pricing: imaginary_tokens'):
         usage = Usage(imaginary_tokens=1)
@@ -68,6 +74,13 @@ def test_usage_assignment_updates_registered_reported_values() -> None:
     usage.input_tokens = None
     assert 'input_tokens' not in usage.__dict__
     assert usage.input_tokens == 0
+
+
+def test_usage_assignment_rejects_invalid_reported_values() -> None:
+    usage = Usage()
+
+    with pytest.raises(ValueError, match='Invalid usage value for input_tokens: expected a non-negative integer'):
+        usage.input_tokens = -1
 
 
 def test_usage_missing_registered_reads_return_zero() -> None:
@@ -156,6 +169,19 @@ def test_usage_from_raw_reads_known_object_attributes() -> None:
     usage = Usage.from_raw(SimpleNamespace(input_tokens=100, output_tokens=50))
 
     assert usage == Usage(input_tokens=100, output_tokens=50)
+
+
+def test_usage_from_raw_rejects_invalid_known_object_attributes() -> None:
+    with pytest.raises(ValueError, match='Invalid usage value for input_tokens: expected a non-negative integer'):
+        Usage.from_raw(SimpleNamespace(input_tokens=1.5))
+
+
+def test_usage_from_raw_revalidates_existing_usage_storage() -> None:
+    usage = Usage()
+    usage.__dict__['input_tokens'] = 1.5
+
+    with pytest.raises(ValueError, match='Invalid usage value for input_tokens: expected a non-negative integer'):
+        Usage.from_raw(usage)
 
 
 def test_usage_from_raw_reads_known_dataclass_attributes() -> None:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -34,6 +34,16 @@ def test_usage_direct_construction_rejects_invalid_reported_values(value: Any) -
         Usage(input_tokens=value)
 
 
+def test_usage_direct_construction_normalizes_integer_subclasses() -> None:
+    class TokenCount(int):
+        pass
+
+    usage = Usage(input_tokens=TokenCount(100))
+
+    assert usage.input_tokens == 100
+    assert type(usage.input_tokens) is int
+
+
 def test_usage_direct_construction_warns_for_unknown_keywords() -> None:
     with pytest.warns(UserWarning, match='Unsupported usage key for standard pricing: imaginary_tokens'):
         usage = Usage(imaginary_tokens=1)


### PR DESCRIPTION
## Summary

Validate recognized Python pricing inputs at the standard runtime boundary.

- reject negative, infinite, and NaN flat and tiered prices
- validate tier thresholds and rates
- reject negative, fractional, non-finite, and boolean values for recognized usage keys
- revalidate stored `Usage` state before standard pricing
- preserve warn-and-ignore behavior for unknown usage and price keys

## Why

The unit-registry specification requires runtime errors for invalid values attached to recognized names. Python previously allowed negative or NaN prices to produce invalid totals, and fractional usage could fail later with an incidental `Decimal` multiplication error.

Validation happens only for registry-recognized standard pricing state, preserving custom subclass and unknown-key behavior.

## Verification

- `make lint`
- `make typecheck`
- `make test` — 662 passed, 41 xfailed, 100% coverage
