### PR TITLE
fix: harden JavaScript provider data activation

### DIFF
--- a/packages/js/src/__tests__/providerActivation.test.ts
+++ b/packages/js/src/__tests__/providerActivation.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Provider, ProviderDataValue } from '../types'
+
+import { findProvider, updatePrices, waitForUpdate } from '../api'
+import { data } from '../data'
+import { getActiveRegistry } from '../units'
+
+afterEach(() => {
+  updatePrices(({ setProviderData }) => {
+    setProviderData(data)
+  })
+  vi.restoreAllMocks()
+})
+
+describe('provider activation', () => {
+  it('warns for unsupported synchronous extractor destinations and preserves the registry', async () => {
+    const registry = getActiveRegistry()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const provider = providerFixture('future-provider', 'future_tokens')
+
+    updatePrices(({ setProviderData }) => {
+      setProviderData([provider])
+    })
+
+    await expect(waitForUpdate()).resolves.toEqual([provider])
+    expect(warn).toHaveBeenCalledWith('Unsupported extractor destination for standard extraction: future_tokens')
+    expect(findProvider({ providerId: 'future-provider' })?.id).toBe('future-provider')
+    expect(getActiveRegistry()).toBe(registry)
+  })
+
+  it('warns for unsupported asynchronous extractor destinations and preserves the registry', async () => {
+    const registry = getActiveRegistry()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const provider = providerFixture('future-async-provider', 'future_tokens')
+
+    updatePrices(({ setProviderData }) => {
+      setProviderData(Promise.resolve([provider]))
+    })
+
+    await expect(waitForUpdate()).resolves.toEqual([provider])
+    expect(warn).toHaveBeenCalledWith('Unsupported extractor destination for standard extraction: future_tokens')
+    expect(findProvider({ providerId: 'future-async-provider' })?.id).toBe('future-async-provider')
+    expect(getActiveRegistry()).toBe(registry)
+  })
+
+  it('rejects invalid synchronous provider data without changing active providers', () => {
+    const stableProvider = providerFixture('stable-provider')
+    updatePrices(({ setProviderData }) => {
+      setProviderData([stableProvider])
+    })
+
+    expect(() => {
+      updatePrices(({ setProviderData }) => {
+        setProviderData('garbage' as unknown as ProviderDataValue)
+      })
+    }).toThrow('Expected null or Provider[]')
+    expect(findProvider({ providerId: 'stable-provider' })?.id).toBe('stable-provider')
+  })
+
+  it('rejects invalid asynchronous provider data without changing active providers', async () => {
+    const stableProvider = providerFixture('stable-provider')
+    updatePrices(({ setProviderData }) => {
+      setProviderData([stableProvider])
+    })
+
+    updatePrices(({ setProviderData }) => {
+      setProviderData(Promise.resolve('garbage' as unknown as ProviderDataValue))
+    })
+
+    await expect(waitForUpdate()).rejects.toThrow('Expected null or Provider[]')
+    expect(findProvider({ providerId: 'stable-provider' })?.id).toBe('stable-provider')
+  })
+})
+
+function providerFixture(providerId: string, dest = 'input_tokens'): Provider {
+  return {
+    api_pattern: 'https://example.com',
+    extractors: [
+      {
+        api_flavor: 'default',
+        mappings: [
+          {
+            dest,
+            path: 'input_tokens',
+            required: true,
+          },
+        ],
+        model_path: 'model',
+        root: 'usage',
+      },
+    ],
+    id: providerId,
+    models: [],
+    name: providerId,
+  }
+}

--- a/packages/js/src/__tests__/providerActivation.test.ts
+++ b/packages/js/src/__tests__/providerActivation.test.ts
@@ -71,6 +71,94 @@ describe('provider activation', () => {
     await expect(waitForUpdate()).rejects.toThrow('Expected null or Provider[]')
     expect(findProvider({ providerId: 'stable-provider' })?.id).toBe('stable-provider')
   })
+
+  it('keeps active providers when an asynchronous update returns null', async () => {
+    const stableProvider = providerFixture('stable-provider')
+    updatePrices(({ setProviderData }) => {
+      setProviderData([stableProvider])
+    })
+
+    updatePrices(({ setProviderData }) => {
+      setProviderData(Promise.resolve(null))
+    })
+
+    await expect(waitForUpdate()).resolves.toEqual([stableProvider])
+    expect(findProvider({ providerId: 'stable-provider' })?.id).toBe('stable-provider')
+  })
+
+  it('recovers waitForUpdate after the latest asynchronous update rejects', async () => {
+    const stableProvider = providerFixture('stable-provider')
+    updatePrices(({ setProviderData }) => {
+      setProviderData([stableProvider])
+    })
+
+    updatePrices(({ setProviderData }) => {
+      setProviderData(Promise.reject(new Error('update failed')))
+    })
+    const failedWait = waitForUpdate()
+
+    await expect(failedWait).rejects.toThrow('update failed')
+    await expect(waitForUpdate()).resolves.toEqual([stableProvider])
+  })
+
+  it('does not let a stale rejected update hide a newer in-flight update', async () => {
+    let rejectStale!: (error: Error) => void
+    let resolveNewer!: (data: ProviderDataValue) => void
+    const staleUpdate = new Promise<ProviderDataValue>((_resolve, reject) => {
+      rejectStale = reject
+    })
+    const newerUpdate = new Promise<ProviderDataValue>((resolve) => {
+      resolveNewer = resolve
+    })
+
+    updatePrices(({ setProviderData }) => {
+      setProviderData(staleUpdate)
+    })
+    const staleWait = waitForUpdate()
+    updatePrices(({ setProviderData }) => {
+      setProviderData(newerUpdate)
+    })
+    const newerWait = waitForUpdate()
+
+    rejectStale(new Error('stale update failed'))
+    await expect(staleWait).rejects.toThrow('stale update failed')
+    expect(waitForUpdate()).toBe(newerWait)
+
+    const newerProvider = providerFixture('newer-provider')
+    resolveNewer([newerProvider])
+    await expect(newerWait).resolves.toEqual([newerProvider])
+    expect(findProvider({ providerId: 'newer-provider' })?.id).toBe('newer-provider')
+  })
+
+  it('does not let a stale successful update overwrite newer provider data', async () => {
+    let resolveStale!: (data: ProviderDataValue) => void
+    let resolveNewer!: (data: ProviderDataValue) => void
+    const staleUpdate = new Promise<ProviderDataValue>((resolve) => {
+      resolveStale = resolve
+    })
+    const newerUpdate = new Promise<ProviderDataValue>((resolve) => {
+      resolveNewer = resolve
+    })
+
+    updatePrices(({ setProviderData }) => {
+      setProviderData(staleUpdate)
+    })
+    const staleWait = waitForUpdate()
+    updatePrices(({ setProviderData }) => {
+      setProviderData(newerUpdate)
+    })
+    const newerWait = waitForUpdate()
+
+    const newerProvider = providerFixture('newer-provider')
+    resolveNewer([newerProvider])
+    await expect(newerWait).resolves.toEqual([newerProvider])
+
+    resolveStale([providerFixture('stale-provider')])
+    await expect(staleWait).resolves.toEqual([newerProvider])
+    expect(waitForUpdate()).toBe(newerWait)
+    expect(findProvider({ providerId: 'newer-provider' })?.id).toBe('newer-provider')
+    expect(findProvider({ providerId: 'stale-provider' })).toBeUndefined()
+  })
 })
 
 function providerFixture(providerId: string, dest = 'input_tokens'): Provider {

--- a/packages/js/src/__tests__/providerActivation.test.ts
+++ b/packages/js/src/__tests__/providerActivation.test.ts
@@ -130,6 +130,34 @@ describe('provider activation', () => {
     expect(findProvider({ providerId: 'newer-provider' })?.id).toBe('newer-provider')
   })
 
+  it('handles a stale rejected update when no caller waited for it', async () => {
+    let rejectStale!: (error: Error) => void
+    let resolveNewer!: (data: ProviderDataValue) => void
+    const staleUpdate = new Promise<ProviderDataValue>((_resolve, reject) => {
+      rejectStale = reject
+    })
+    const newerUpdate = new Promise<ProviderDataValue>((resolve) => {
+      resolveNewer = resolve
+    })
+
+    updatePrices(({ setProviderData }) => {
+      setProviderData(staleUpdate)
+    })
+    updatePrices(({ setProviderData }) => {
+      setProviderData(newerUpdate)
+    })
+    const newerWait = waitForUpdate()
+
+    rejectStale(new Error('unobserved stale update failed'))
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0)
+    })
+
+    const newerProvider = providerFixture('newer-provider')
+    resolveNewer([newerProvider])
+    await expect(newerWait).resolves.toEqual([newerProvider])
+  })
+
   it('does not let a stale successful update overwrite newer provider data', async () => {
     let resolveStale!: (data: ProviderDataValue) => void
     let resolveNewer!: (data: ProviderDataValue) => void

--- a/packages/js/src/api.ts
+++ b/packages/js/src/api.ts
@@ -24,7 +24,20 @@ function setProviderData(data: ProviderDataPayload) {
     return
   }
   if (typeof data === 'object' && 'then' in data) {
-    providerDataPromise = data.then((data) => (data === null ? null : activateProviderData(data)))
+    const updatePromise = data
+      .then((data) => {
+        if (data === null || providerDataPromise !== updatePromise) {
+          return providerData
+        }
+        return activateProviderData(data)
+      })
+      .catch((error: unknown) => {
+        if (providerDataPromise === updatePromise) {
+          providerDataPromise = Promise.resolve(providerData)
+        }
+        throw error
+      })
+    providerDataPromise = updatePromise
   } else {
     providerDataPromise = Promise.resolve(activateProviderData(data))
   }

--- a/packages/js/src/api.ts
+++ b/packages/js/src/api.ts
@@ -37,6 +37,10 @@ function setProviderData(data: ProviderDataPayload) {
         }
         throw error
       })
+    // Updates may be fire-and-forget. Observe failures without changing the
+    // original promise returned by waitForUpdate() to callers that do await it.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    updatePromise.catch(() => undefined)
     providerDataPromise = updatePromise
   } else {
     providerDataPromise = Promise.resolve(activateProviderData(data))

--- a/packages/js/src/api.ts
+++ b/packages/js/src/api.ts
@@ -10,6 +10,7 @@ import type {
 
 import { data as embeddedData } from './data'
 import { calcPrice as calcPriceInternal, getActiveModelPrice, matchModelWithFallback, matchProvider } from './engine'
+import { warnUnsupportedExtractorDestinations } from './validation'
 
 export const REMOTE_DATA_JSON_URL = 'https://raw.githubusercontent.com/pydantic/genai-prices/main/prices/data.json'
 
@@ -22,18 +23,21 @@ function setProviderData(data: ProviderDataPayload) {
   if (data === null) {
     return
   }
-  if ('then' in data) {
-    providerDataPromise = data
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    data.then((data) => {
-      if (data !== null) {
-        providerData = data
-      }
-    })
+  if (typeof data === 'object' && 'then' in data) {
+    providerDataPromise = data.then((data) => (data === null ? null : activateProviderData(data)))
   } else {
-    providerDataPromise = Promise.resolve(data)
-    providerData = data
+    providerDataPromise = Promise.resolve(activateProviderData(data))
   }
+}
+
+function activateProviderData(data: Provider[]): Provider[] {
+  if (!Array.isArray(data)) {
+    throw new Error('Expected null or Provider[]')
+  }
+
+  warnUnsupportedExtractorDestinations(data)
+  providerData = data
+  return data
 }
 
 function onCalc(cb: () => void) {


### PR DESCRIPTION
## Summary

- Validate provider-array payloads before activation and warn once for extractor destinations unsupported by the bundled registry.
- Keep the active provider data when an asynchronous update returns `null` or the latest update rejects.
- Make concurrent asynchronous updates last-writer-wins so stale successes and failures cannot replace or hide newer data.

## Why

This updater hardening was split out of #512 so the static-registry v2 publication PR can remain focused on publishing and consuming the new provider-data URL. These changes are independent of the v2 endpoint and retain the existing v1 update URL.

## Verification

- Full JavaScript suite: 743 passed, 1 skipped.
- JavaScript typecheck passed.
- JavaScript lint passed.
