### PR TITLE
Refresh agent-facing docs for the v2 data contract

### DIFF
--- a/.claude/skills/add-price-model/SKILL.md
+++ b/.claude/skills/add-price-model/SKILL.md
@@ -9,8 +9,9 @@ description: >-
 
 # Add a model to genai-prices
 
-Never edit `prices/data.json` / `prices/data_slim.json` by hand — they are generated. Edit the
-provider YAML in `prices/providers/<provider>.yml`, then `make build-prices`.
+Never hand-edit generated data. Edit the provider YAML in `prices/providers/<provider>.yml`, then
+`make build`. The live published payload is `prices/new_data/v2/data.json`; `prices/data.json` and
+`prices/data_slim.json` are **frozen v1** snapshots that no build step writes any more — leave them alone.
 
 ## 0. Scope: every provider that hosts this model, not just the one you were named
 
@@ -91,6 +92,16 @@ fields). Include:
 
 Add a `price_comments` field when a value needs explanation/reference.
 
+Those three keys cover the common case. The full vocabulary is derived from `prices/units.yml` — check
+it when the model bills for anything else (reasoning or citation tokens, per-modality rates, 1h cache
+writes, web searches, requests). **Not every key is per-Mtok:** `_kcount` is per 1,000, `_mchars` per
+1M characters, `_hours` per 3,600s, `_gpixels` per 1e9, `_kpages` per 1,000. A per-Mtok figure under a
+`_kcount` key is valid YAML and wrong by 1000×. Prices must also cover their ancestors — a model with
+`cache_write_1h_mtok` needs `cache_write_mtok` too; `make build` will tell you which key is missing.
+
+Do **not** add a new unit to `prices/units.yml` to make a model fit. That widens the published v2
+schema and is a v3 change — see `AGENTS.md` § "Adding a unit". Open an issue instead.
+
 **Migrate family-level `-latest` aliases when the new model is the current flagship.** Two kinds of
 `-latest` alias coexist, and they behave differently:
 
@@ -107,10 +118,10 @@ alias at all).
 ## 5. Build + verify resolution
 
 Use `make build`, not just `make build-prices`. The installed `genai_prices` package (and the JS
-package) read their **bundled** data (`packages/python/genai_prices/data.py`, `packages/js/src/data.ts`)
-— NOT `prices/data.json`. `make build-prices` only writes `prices/data.json`, so a `calc_price` check
-run after it verifies **stale** package data and can silently show the wrong result. `make build` runs
-`build-prices` + `package-data` + `inject-providers`.
+package) read their **bundled** data (`packages/python/genai_prices/data.py`, `packages/js/src/data.ts`).
+`make build-prices` writes only `prices/new_data/v2/*` and `prices/providers/.schema.json` — it does not
+touch the bundled data, so a `calc_price` check run after it verifies **stale** package data and can
+silently show the wrong result. `make build` runs `build-prices` + `package-data` + `inject-providers`.
 
 ```bash
 make build    # build-prices + package-data + inject-providers
@@ -132,19 +143,27 @@ for m in ['<id>', '<id>-<YYYYMMDD>', '<provider>/<id>-<YYYYMMDD>', '<provider>-l
 
 ## 6. Commit, push, PR
 
-Pre-commit hooks regenerate more than the JSON — **README.md**, **packages/js/src/data.ts**, and
-**packages/python/genai_prices/data.py**. The first `git commit` will abort after the hooks rewrite
-these; re-stage the regenerated files and commit again.
-
-Stage files explicitly — **never `git add -A`** (it leaks local/scratch files):
+The pre-commit `build` hook regenerates nine paths, so the first `git commit` will abort after it
+rewrites them; re-stage and commit again. Stage files explicitly — **never `git add -A`** (it leaks
+local/scratch files) — and never `--no-verify`, since that hook is what keeps the published data in
+sync with the YAML:
 
 ```bash
-git add prices/providers/<provider>.yml prices/data.json prices/data_slim.json \
-        README.md packages/js/src/data.ts packages/python/genai_prices/data.py
+git add prices/providers/<provider>.yml \
+        prices/providers/.schema.json \
+        prices/new_data/v2/data.json prices/new_data/v2/data.schema.json \
+        prices/new_data/v2/data_slim.json prices/new_data/v2/data_slim.schema.json \
+        packages/python/genai_prices/data.py packages/python/genai_prices/data_units.py \
+        packages/js/src/data.ts packages/js/src/dataUnits.ts \
+        README.md
 git commit -m "Add <Provider> <Model> pricing"   # re-run once if hooks rewrite files
 git push -u origin <slug>
 gh pr create --base main --title "Add <Provider> <Model> pricing" --body "..."
 ```
+
+A plain price addition usually only dirties a subset of these — `git status` after the aborted commit
+tells you which. The schema and `*_units` files change only when `prices/units.yml` does, which a price
+addition should not do.
 
 Never force-push. PR body: pricing table, sources (provider docs + OpenRouter for cache rate), and
 scope notes (e.g. single variant / no cache-write / any `-latest` alias you moved, each with its

--- a/.claude/skills/add-price-model/SKILL.md
+++ b/.claude/skills/add-price-model/SKILL.md
@@ -143,7 +143,7 @@ for m in ['<id>', '<id>-<YYYYMMDD>', '<provider>/<id>-<YYYYMMDD>', '<provider>-l
 
 ## 6. Commit, push, PR
 
-The pre-commit `build` hook regenerates nine paths, so the first `git commit` will abort after it
+The pre-commit `build` hook regenerates ten paths, so the first `git commit` will abort after it
 rewrites them; re-stage and commit again. Stage files explicitly — **never `git add -A`** (it leaks
 local/scratch files) — and never `--no-verify`, since that hook is what keeps the published data in
 sync with the YAML:

--- a/.github/workflows/agentic-price-check-google-mistral.md
+++ b/.github/workflows/agentic-price-check-google-mistral.md
@@ -80,14 +80,26 @@ Step 4 combines both into a single issue (built fresh each run, replacing the pr
 ## Step 1 — read the recorded prices
 
 Run `cat prices/providers/google.yml` (then `mistral.yml`). Under `models:` each
-entry has an `id`, a `match`, and a `prices:` block. Every number is **USD per
-1,000,000 tokens**. The fields you check:
+entry has an `id`, a `match`, and a `prices:` block.
+
+**Check every key under `prices:`, not a fixed list** — the vocabulary grows, and a key you skip is a
+discrepancy nobody sees. The key suffix tells you the unit, and they are **not** all per-million-tokens:
+`_mtok` is USD per 1,000,000 tokens, `_kcount` per 1,000 (`web_searches_kcount`, `requests_kcount`),
+`_mchars` per 1M characters, `_hours` per 3,600 seconds, `_gpixels` per 1e9 pixels, `_kpages` per 1,000
+pages. Convert the page's figure into the key's unit before comparing, and show the arithmetic in the
+issue row.
+
+The ones you will see most often here:
 
 - `input_mtok` — standard **text** input price
 - `output_mtok` — output price
 - `cache_read_mtok` — cached input price (check only when the page lists one)
 - `input_audio_mtok` — audio input price, on Gemini models that have it (compare it to the page's audio input rate, separately from text)
 - `cache_audio_read_mtok` — cached **audio** input price, on Gemini models that have it (compare to the page's audio context-cache rate, check only when the page lists one)
+- `input_image_mtok` / `input_video_mtok` / `output_image_mtok` — per-modality rates where the page quotes them separately
+
+If a key has no counterpart you can identify on the page, **do not treat it as matching** — list it in
+the issue as unchecked with the key name. A silent skip reads as a clean bill of health.
 
 Some Gemini entries are tiered by prompt size, e.g.
 `input_mtok: {base: 1.25, tiers: [{start: 200000, price: 2.5}]}`. Use the `base`

--- a/.github/workflows/agentic-price-check-openai-anthropic.md
+++ b/.github/workflows/agentic-price-check-openai-anthropic.md
@@ -92,12 +92,23 @@ entry looks like this:
     cache_read_mtok: 1.25
 ```
 
-Every number in `prices:` is **USD per 1,000,000 tokens**. The fields you check:
+**Check every key under `prices:`, not a fixed list** — the vocabulary grows, and a key you skip is a
+discrepancy nobody sees.
 
-- `input_mtok` — standard input price
-- `output_mtok` — output price
-- `cache_read_mtok` — cached / cache-hit input price (check only when the page lists a cache price)
-- `cache_write_mtok` — cache-write price (check only when the page lists one)
+The key suffix tells you the unit, and they are **not** all per-million-tokens:
+
+- `_mtok` — USD per 1,000,000 tokens (`input_mtok`, `output_mtok`, `cache_read_mtok`,
+  `cache_write_mtok`, `cache_write_1h_mtok`, `output_reasoning_mtok`, `input_image_mtok`, …)
+- `_kcount` — USD per 1,000 (`web_searches_kcount`, `requests_kcount`)
+- `_mchars` per 1M characters, `_hours` per 3,600 seconds, `_gpixels` per 1e9 pixels, `_kpages` per 1,000 pages
+
+Convert the page's figure into the key's unit before comparing, and show the arithmetic in the issue row.
+
+Note `cache_write_mtok` and `cache_write_1h_mtok` are different keys: the plain one is the default
+(5-minute) TTL, the `_1h` one is the 1-hour TTL. Match each against its own column.
+
+If a key has no counterpart you can identify on the page, **do not treat it as matching** — list it in
+the issue as unchecked with the key name. A silent skip reads as a clean bill of health.
 
 A few entries are tiered, e.g. `input_mtok: {base: 3, tiers: [{start: 200000, price: 6}]}`.
 Use the `base` value (here `3`) and set the tiers aside.
@@ -130,8 +141,11 @@ number the page didn't give you.
 - Page: <https://platform.claude.com/docs/en/about-claude/pricing.md>
 - Read the "Model pricing" table. Map its columns to the YAML fields:
   **Base Input Tokens** → `input_mtok`, **Output Tokens** → `output_mtok`,
-  **5m Cache Writes** → `cache_write_mtok`, **Cache Hits & Refreshes** →
-  `cache_read_mtok`. A cell like "$5 / MTok" means `5`.
+  **5m Cache Writes** → `cache_write_mtok`, **1h Cache Writes** → `cache_write_1h_mtok`,
+  **Cache Hits & Refreshes** → `cache_read_mtok`. A cell like "$5 / MTok" means `5`.
+- Anthropic entries may also carry `web_searches_kcount`, priced per **1,000 searches**. The pricing
+  page lists web search under its tool-use / agent-tools section, not the model table — a page figure
+  of "$10 per 1,000 searches" means `10`.
 
 ## Step 3 — match models and compare
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ closure rules.
 ### Development Workflow
 
 - Use `uv` for dependency management (not pip/conda), `npm` for the JS workspace
-- The pre-commit `build` hook fires on any change under `prices/` and rewrites **nine** paths:
+- The pre-commit `build` hook fires on any change under `prices/` and rewrites **ten** paths:
   `prices/providers/.schema.json`, the four `prices/new_data/v2/*` files, `data.py`, `data_units.py`,
   `data.ts`, `dataUnits.ts`, plus `README.md` (provider list). Your first `git commit` will abort after
   it rewrites them — re-stage the regenerated files and commit again. Never reach for `--no-verify`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,10 @@ to this file, so every harness reads the same instructions.
 
 This is the GenAI Prices project - a database and tools for calculating LLM inference API pricing. The project includes:
 
-- **Price Data**: YAML files in `prices/providers/` with pricing information for 16+ LLM providers
-- **Python Package**: Located in `packages/python/` - a Python library for calculating costs
+- **Price Data**: YAML files in `prices/providers/` with pricing information for 30+ LLM providers
+- **Unit Registry**: `prices/units.yml` defines every billable unit and its price key
+- **Packages**: `packages/python/` (PyPI `genai-prices`) and `packages/js/` (npm `@pydantic/genai-prices`) —
+  two implementations that must stay behaviourally identical
 - **Data Pipeline**: Tools to build JSON schemas, validate data, and update from external sources
 - **Price Sources**: Integration with Helicone, OpenRouter, LiteLLM, and other pricing sources
 
@@ -17,18 +19,25 @@ This is the GenAI Prices project - a database and tools for calculating LLM infe
 ### Core Components
 
 1. **Price Data Sources** (`prices/providers/*.yml`): YAML files containing model pricing information for each provider
-2. **Data Pipeline** (`prices/src/prices/`): Python modules that build, validate, and process pricing data
-3. **Python Package** (`packages/python/`): Published package for end users to calculate costs
-4. **External Data Integration**: Tools to pull and compare prices from external sources
+2. **Unit Registry** (`prices/units.yml`): the vocabulary of billable units — every valid price key and
+   extractor destination is derived from it
+3. **Data Pipeline** (`prices/src/prices/`): Python modules that build, validate, and process pricing data
+4. **Packages** (`packages/python/`, `packages/js/`): published libraries for end users to calculate costs
+5. **External Data Integration**: Tools to pull and compare prices from external sources
 
 ### Key Directories
 
 - `prices/`: Core pricing data and build tools
   - `providers/`: YAML files with provider-specific pricing
+  - `units.yml`: the unit registry (see "Adding a unit" below before editing)
   - `src/prices/`: Python package for data processing
-  - `data.json` and `data_slim.json`: Built JSON files (DO NOT EDIT DIRECTLY)
-- `packages/python/`: Published Python package for users
-- `tests/`: Python Test suite
+  - `new_data/v2/`: the **live** published data — `data.json`, `data_slim.json` and their schemas (generated)
+  - `data.json`, `data_slim.json` + schemas: **frozen v1** compatibility snapshots (see "Pricing Data")
+- `packages/python/`, `packages/js/`: published packages. `data.py`/`data.ts` and `data_units.py`/`dataUnits.ts`
+  are generated — never hand-edit them
+- `tests/`: Python test suite; JS tests live in `packages/js/src/__tests__/`
+- `specs/data-driven-unit-registry/`: authoritative design docs for the unit registry and the v1/v2/v3
+  contract rules. Read these before changing anything about units or published artifacts
 - `scratch/`: Development/testing files IGNORE THESE FILES
 
 ## Development Commands
@@ -46,16 +55,25 @@ make sync         # Update local packages and uv.lock
 make format       # Format code with ruff
 make lint         # Check code style and linting
 make typecheck    # Run static type checking with basedpyright
-make test         # Run tests with coverage
+make test         # Run the Python tests with coverage (does NOT run the JS suite)
 make testcov      # Run tests and generate HTML coverage report
+npm run ci        # Build and test the JS package — no Make target runs this
 ```
+
+`make all` covers the Python side only. Run `npm run ci` yourself before pushing anything that
+touches `packages/js/` or regenerates package data.
 
 ### Building and Data Processing
 
 ```bash
-make build-prices # Build JSON schema and validate/write data to prices/data.json
-make package-data # Prepare data for packages
+make build        # build-prices + package-data + inject-providers — use this one
+make build-prices # Validate providers and write prices/new_data/v2/* + prices/providers/.schema.json
+make package-data # Regenerate the bundled data in packages/python/ and packages/js/
 ```
+
+Always run `make build`, not `make build-prices` alone. The installed packages read their **bundled**
+data (`packages/python/genai_prices/data.py`, `packages/js/src/data.ts`), which only `package-data`
+regenerates — so a `calc_price` check run after `build-prices` verifies stale data.
 
 ### Price Data Management
 
@@ -65,31 +83,90 @@ make helicone-get                      # Get Helicone prices
 make openrouter-get                    # Get OpenRouter prices
 make litellm-get                       # Get LiteLLM prices
 make simonw-prices-get                 # Get Simon Willison's prices
+make huggingface-get                   # Get HuggingFace prices
+make ovhcloud-get                      # Get OVHcloud AI Endpoints prices
 make get-update-price-discrepancies    # Download and update price discrepancies
 make check-for-price-discrepancies     # Check for price discrepancies
+make detect-deprecated                 # Detect models that may be deprecated or removed
+make collapse-models                   # Collapse duplicate similar models
 ```
+
+`make help` lists every target. These importers run against live third-party APIs and nothing in CI
+exercises them, so they break silently when an upstream schema changes — if one returns suspiciously
+little, suspect the importer before the data.
 
 ## Important Notes
 
 ### Pricing Data
 
-- **NEVER** edit `prices/data.json` or `prices/data_slim.json` directly - they are generated files
+- **v2 is the live feed.** `prices/new_data/v2/data.json` is what the published packages auto-update
+  from, and it goes live on merge to `main` — independent of any package release.
+- **v1 is frozen.** `prices/data.json` and `prices/data_slim.json` are compatibility snapshots for
+  pre-0.1.0 clients. No build step writes them any more, and they receive no provider, model or price
+  updates. Don't regenerate them, don't hand-edit them, and don't treat their stale `prices_checked`
+  dates as a bug.
+- **NEVER** hand-edit any generated file: the v2 payloads and schemas, `prices/providers/.schema.json`,
+  or the bundled `data.py` / `data.ts` / `data_units.py` / `dataUnits.ts`. Edit the provider YAML or
+  `prices/units.yml` and run `make build`.
+- Published artifact URLs must not change — new contracts go in a new `prices/new_data/v<version>/`
+  directory rather than moving or renaming existing files.
 - When updating prices in YAML files, always update the `prices_checked` field to current date
 - Add `price_comments` to explain changes and provide references
-- URLs for `data.json` and `data_slim.json` must not change (used by auto-update feature)
+
+### Authoring provider YAML
+
+- The valid `prices:` keys and extractor `dest:` values are **derived from `prices/units.yml`**, not
+  hardcoded anywhere. `prices/providers/.schema.json` is the generated list; your IDE reads it via the
+  `# yaml-language-server:` header, but on the CLI read `units.yml` directly.
+- **Not every price key is per-million-tokens.** `_mtok` is per 1M, `_kcount` is per 1,000 (e.g.
+  `requests_kcount`, `web_searches_kcount`), `_mchars` per 1M characters, `_hours` per 3,600 seconds,
+  `_gpixels` per 1e9, `_kpages` per 1,000. Putting a per-Mtok figure under a `_kcount` key is valid
+  YAML and silently wrong by 1000×.
+- Prices must cover their **ancestors and joins**: a model priced with `cache_write_1h_mtok` also needs
+  `cache_write_mtok`, and so on. `make build` enforces this; the error names the missing key.
+
+### Adding a unit
+
+**Adding a unit to `prices/units.yml` is a v3 change, not a v2 price update.** `make build` regenerates
+`prices/new_data/v2/data.schema.json` from the registry, so adding a unit silently widens the published
+v2 contract — and clients that haven't upgraded warn-and-drop the unknown key rather than failing, which
+means silently under-priced usage in production. Nothing currently blocks this; the constraint is stated
+in `specs/data-driven-unit-registry/phase-1-static-unit-registry-release/code-spec.md` and is a
+maintainer responsibility. Read that spec first, and see the header comment in `units.yml` for the
+closure rules.
 
 ### Development Workflow
 
-- Use `uv` for dependency management (not pip/conda)
-- Pre-commit hooks will automatically update JSON files when YAML prices change
-- Run `make build` after editing provider YAML files
+- Use `uv` for dependency management (not pip/conda), `npm` for the JS workspace
+- The pre-commit `build` hook fires on any change under `prices/` and rewrites **nine** paths:
+  `prices/providers/.schema.json`, the four `prices/new_data/v2/*` files, `data.py`, `data_units.py`,
+  `data.ts`, `dataUnits.ts`, plus `README.md` (provider list). Your first `git commit` will abort after
+  it rewrites them — re-stage the regenerated files and commit again. Never reach for `--no-verify`:
+  that hook is the only thing keeping the published data in sync with the YAML.
+- Run `make build` after editing anything under `prices/`
 - Always run the full test suite before submitting changes
 
 ### Testing
 
-- Tests use pytest with coverage reporting
-- Test files are in `tests/` directory
+- Python tests use pytest and are in `tests/`; JS tests are in `packages/js/src/__tests__/` and run
+  via `npm run ci`
+- CI enforces **100% Python coverage** on `packages/python/**` and `tests/**`. Local `make test` runs
+  `coverage report --fail-under=0`, so a green `make test` does not mean the coverage gate will pass.
+- `make test` also runs `tests/dataset/extract_usages.py`, which **rewrites** `tests/dataset/usages.json`
+  and then fails if it changed. That is the cross-language golden dataset — the regenerated file is
+  usually the correct new state, so inspect the diff and commit it rather than reverting. Because it
+  writes before comparing, a second `make test` always passes; don't read that as a fix.
+- Price changes are pinned by assertions in `tests/test_price_calc.py` and `tests/test_price_regressions.py`.
+  Update the expected values; don't weaken or delete the assertion.
 - Use `make test-all-python` to test across Python 3.10-3.14
+
+### Python/JS parity
+
+The two packages are independent implementations of the same behaviour and are the easiest place to
+introduce drift. Any change to pricing, extraction, matching or unit handling must land on both sides.
+`tests/dataset/usages.json` is generated by Python and asserted by JS, so it catches arithmetic drift on
+the models real data covers — but it pins a single UTC instant and only the units shipped prices use, so
+it does not catch constraint-resolution, matching, warning or error-shape divergence.
 
 ### Code Style
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,14 @@ Price data is available in the following files:
 - [`prices/new_data/v2/data.schema.json`](prices/new_data/v2/data.schema.json) - JSON Schema for the full v2 data
 - [`prices/new_data/v2/data_slim.json`](prices/new_data/v2/data_slim.json) - compact v2 pricing data with free models and long metadata removed
 - [`prices/new_data/v2/data_slim.schema.json`](prices/new_data/v2/data_slim.schema.json) - JSON Schema for the slim v2 data
-- [`prices/data.json`](prices/data.json) - v1-compatible provider and model pricing data
-- [`prices/data.schema.json`](prices/data.schema.json) - v1 JSON Schema for `prices/data.json`
-- [`prices/data_slim.json`](prices/data_slim.json) - slim v1-compatible data with long fields and free models removed
-- [`prices/data_slim.schema.json`](prices/data_slim.schema.json) - v1 JSON Schema for `prices/data_slim.json`
+
+The v1 files below are **frozen**: they remain available so released clients keep working, but they no
+longer receive provider, model or price updates. Use the v2 files above for anything new.
+
+- [`prices/data.json`](prices/data.json) - frozen v1-compatible provider and model pricing data
+- [`prices/data.schema.json`](prices/data.schema.json) - JSON Schema published alongside frozen v1 `data.json`
+- [`prices/data_slim.json`](prices/data_slim.json) - frozen slim v1-compatible data with long fields and free models removed
+- [`prices/data_slim.schema.json`](prices/data_slim.schema.json) - JSON Schema published alongside frozen v1 `data_slim.json`
 
 Feel free to download these files and use them as you wish. We would be grateful if you would reference this
 project wherever you use it and [contribute](#contributing) back to the project if you find any errors.

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -97,11 +97,20 @@ const result = calcPrice(usage, 'my-new-model', { provider: customProvider })
 - `Provider`: `id`, `name`, `api_pattern`, and `models` array
 - `ModelInfo`: `id`, `match` (determines how the model ID is matched), and `prices`
 
-**Pricing fields** (all in cost per million tokens):
+**Pricing fields.** The full set is derived from
+[`prices/units.yml`](https://github.com/pydantic/genai-prices/blob/main/prices/units.yml); the common
+per-million-token ones are:
 
 - `input_mtok` / `output_mtok`: Text token pricing
 - `cache_read_mtok` / `cache_write_mtok`: Prompt caching pricing
 - `input_audio_mtok` / `output_audio_mtok`: Audio token pricing
+
+The key suffix tells you the unit, and **not every key is per million**: `_mtok` is per 1M tokens,
+`_kcount` per 1,000 (e.g. `requests_kcount`, `web_searches_kcount`), `_mchars` per 1M characters,
+`_hours` per 3,600 seconds, `_gpixels` per 1e9 pixels, `_kpages` per 1,000 pages.
+
+Prices must also cover their ancestors: a model priced with `cache_write_1h_mtok` needs
+`cache_write_mtok` as well, or pricing throws at runtime.
 
 ### Error Handling
 

--- a/prices/README.md
+++ b/prices/README.md
@@ -8,6 +8,10 @@ version-suffixed files to the flat `prices/` directory.
 
 These files are downloaded by packages to auto-update prices, so their URLs must not change.
 
+**v1 is frozen.** `prices/data.json` and `prices/data_slim.json` are compatibility snapshots for clients released
+before v2. No build step writes them, and they receive no provider, model or price updates. `prices/new_data/v2/`
+is the live feed.
+
 ## Contributing
 
 We welcome contributions from the community and especially model/inference providers!
@@ -29,7 +33,9 @@ When you edit the prices of a model, remember to:
 Please do not:
 
 - edit generated JSON files directly — edit the provider YAML and use `make build` instead
-- modify the v1 compatibility artifacts in a way the baseline v1 clients cannot consume
+- modify the frozen v1 compatibility artifacts at all
+- add a unit to `units.yml` to make a model fit — that widens the published v2 schema and is a v3 change,
+  see the header comment in that file
 - add verbose descriptions to providers or models, we only need enough detail to give the end user a rough idea of the model's capabilities
 - try to change the schema of providers or models without creating an issue to discuss the changes first
 - add new providers without creating an issue to discuss the changes first, adding models is fine

--- a/prices/units.yml
+++ b/prices/units.yml
@@ -1,3 +1,30 @@
+# The unit registry: the single source of truth for every billable unit.
+#
+# ADDING A UNIT HERE IS A v3 CHANGE, NOT A v2 PRICE UPDATE.
+# `make build` regenerates prices/new_data/v2/data.schema.json from this file — it adds a property per
+# price_key and rebuilds the extractor `dest` enum. So editing this file silently widens the *published*
+# v2 contract. Clients that haven't upgraded warn-and-drop an unknown key rather than failing, which
+# means silently under-priced usage in production. Nothing enforces this; it is a maintainer
+# responsibility. Read specs/data-driven-unit-registry/phase-1-static-unit-registry-release/code-spec.md
+# before touching this file.
+#
+# Each entry maps a usage key (what a provider reports) to how it is priced:
+#   per        - how many usage counts one price unit covers (1_000_000 tokens, 1_000 searches, 3_600
+#                seconds...). Every unit in a `family` must share the same `per`.
+#   price_key  - the key providers use under `prices:`. Defaults to the usage key when identical.
+#   dimensions - what this unit *is*. Containment defines ancestry (input_tokens is an ancestor of
+#                cache_read_tokens), and compatible unions define joins. `family` is required; a unit
+#                with no `direction` contributes to total_price but to neither input nor output.
+#   dimension_requirements - conditional validity, e.g. cache_ttl only means something on a cache_write.
+#
+# Two closure rules are enforced by prices/src/prices/export_validation.py::validate_units, so adding
+# one unit usually forces adding several:
+#   interval closure - every dimension set between an ancestor and a descendant must also exist
+#   join closedness  - any two units whose dimensions can be combined need that combination to exist
+#
+# Adding a unit here does NOT make it priceable on its own — a provider YAML has to use the price_key,
+# and it must also price the unit's ancestors and joins.
+
 input_tokens:
   per: 1_000_000
   price_key: input_mtok


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David reviewed it lightly.

Docs-only. Every agent-facing file in the repo still described the pre-#512 world, so an AI assistant following them takes concrete wrong actions today. No code, no generated artifacts (`make build` produces no diff on this branch).

Companion to #533, which covers the bugs and verification gaps from the same audit.

## What was wrong, and what each stale line makes an agent do

| File | Said | Does |
|---|---|---|
| `AGENTS.md` | "`make build-prices` … write data to `prices/data.json`" | Agent regenerates, diffs `prices/data.json`, sees nothing, concludes the build is broken — and the plausible "fix" is making `build.py` emit v1 again, reversing the freeze |
| `AGENTS.md` | never mentions `packages/js/` | Python-only changes ship; `make all` is green with a broken JS package (there is no npm target in the Makefile) |
| `add-price-model` skill | `git add … prices/data.json prices/data_slim.json …` | Stages two frozen files and **omits both v2 payloads** — the actual published feed — while the skill explicitly forbids `git add -A` |
| `add-price-model` skill | "`make build-prices` only writes `prices/data.json`" | Correct instruction (*use `make build`*) resting on a false premise; an agent that checks the premise may discard the instruction |
| `prices/units.yml` | no comments at all | Agent asked to add per-image pricing edits the registry, hits an opaque closure error, brute-forces units until the build passes — silently widening the published v2 schema, which is a v3 change |
| price-check prompts | "Every number in `prices:` is USD per 1,000,000 tokens" + 4 hardcoded fields | `anthropic.yml` now carries `cache_write_1h_mtok` and `web_searches_kcount: 10`. The weekly agent skips them and files "All OpenAI + Anthropic prices match" — false assurance is worse than no check |
| `packages/js/README.md` | "**Pricing fields** (all in cost per million tokens)" | A custom provider for a search- or request-billed model gets a per-Mtok figure under a `_kcount` key. No error; wrong by 1000× |
| `README.md`, `prices/README.md` | v1 listed with no freeze marker; "modify the v1 compatibility artifacts **in a way baseline clients cannot consume**" | Reads as "v1 is still maintained". Points a downstream project at a frozen feed |

## Changes

**`AGENTS.md`** — the main rewrite. v1 frozen / v2 live; the nine paths `make build` regenerates and why `--no-verify` is never the answer; the JS package and `npm run ci` (no Make target runs it); a new **Authoring provider YAML** section covering the unit-suffix table and ancestor/join coverage; a new **Adding a unit** section stating the v3 constraint; testing gotchas that currently cost real time (local `--fail-under=0` vs CI's 100, and `usages.json` being rewritten-then-compared so the second `make test` always passes); a **Python/JS parity** section naming what the golden dataset does and does not catch.

**`prices/units.yml`** — header comment: what `per` / `price_key` / `dimensions` / `dimension_requirements` mean, the interval-closure and join-closedness rules enforced by `export_validation.py::validate_units`, and the v3 constraint from `specs/data-driven-unit-registry/phase-1-static-unit-registry-release/code-spec.md`. Placed here rather than in a separate doc because it is read at the exact moment of the edit it needs to prevent.

**`.claude/skills/add-price-model/SKILL.md`** — corrected build rationale; a `git add` list that stages the v2 payloads; a pointer to `units.yml` for anything beyond the three common keys, with the suffix table; and an explicit "don't add a unit to make a model fit — open an issue".

**Both price-check prompts** — "check every key under `prices:`", the suffix→unit table, 1h cache writes and web searches mapped for Anthropic, per-modality rates for Google, and: *if a key has no counterpart on the page, list it as unchecked — never report it as matching.* Body-only edits; both locks use `{{#runtime-import}}` for the body, so no `gh aw compile` is needed (verified).

**READMEs** — v1 marked frozen in both; `prices/README.md`'s "don't modify v1 *in a way clients can't consume*" tightened to "don't modify the frozen v1 artifacts at all", plus a don't-add-units line; JS README's price-field list corrected and given the ancestor-coverage rule.

## Verification

`make build` produces no diff on this branch — the `units.yml` comment changes no generated output. Pre-commit passes.

## Scope decisions, flagged as deliberate

- **No nested `prices/providers/AGENTS.md`.** It was the natural home for the authoring rules, but it would duplicate content that has to stay in sync. Those rules went into the root `AGENTS.md` instead, which is harness-neutral — worth noting because `add-price-model` is a Claude-only skill, so Codex and other harnesses previously got only the stale root file.
- **`specs/data-driven-unit-registry/**` left as-is.** It is accurate and authoritative; the problem was that nothing linked to it. `AGENTS.md` and `units.yml` now do.
- **`AGENTS.md` "16+ providers" → "30+"** and the missing Make targets added, though neither induced a wrong action — cheap while in the file.
- **No CI or test changes here.** All of that is #533's PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

