### PR TITLE
Collapse generated diffs, pin the frozen v1 snapshots, document price-history preservation

### DIFF
--- a/.claude/skills/add-price-model/SKILL.md
+++ b/.claude/skills/add-price-model/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: add-price-model
 description: >-
-  Add a new LLM model (or provider) to genai-prices pricing data. Use when asked to add/update
-  pricing for a model — e.g. "add grok 4.5", "add the new Claude", "update openai o5 prices". Covers
-  sourcing prices, probing OpenRouter for undocumented dated snapshot IDs, editing the provider YAML,
-  building, verifying resolution, and opening the PR.
+  Add a new LLM model (or provider) to genai-prices pricing data, or change the price of one that is
+  already there. Use when asked to add/update pricing for a model — e.g. "add grok 4.5", "add the new
+  Claude", "update openai o5 prices", "provider X cut its prices". Covers sourcing prices, probing
+  OpenRouter for undocumented dated snapshot IDs, editing the provider YAML, preserving price history
+  across a rate change, building, verifying resolution, and opening the PR.
 ---
 
 # Add a model to genai-prices
@@ -114,6 +115,57 @@ entry** (add it here, delete it there). First verify which model the vendor's al
 to — check the provider docs and, if you can, hit the API and read the response `model` field — then
 match that. Don't assume; the aliasing scheme is provider-specific (some vendors have no bare-family
 alias at all).
+
+## 4b. Changing the price of a model that already exists
+
+A provider changing its rates is **not** an edit to the existing `prices:` block. Overwriting those
+values re-prices every request the library ever priced for that model, so a request from before the
+change gets billed at the new rate. That is what happened to GPT-5.6 Luna and Terra in #531, and #535
+had to undo it.
+
+Add a dated entry instead. Convert `prices:` from a mapping to a list of conditional entries:
+
+```yaml
+prices:
+  - prices: # the rates that were already there, unchanged and unconstrained
+      input_mtok: 1
+      output_mtok: 6
+  - constraint:
+      # https://developers.openai.com/api/docs/changelog
+      start_date: 2026-07-30
+    prices: # the new rates
+      input_mtok: 0.2
+      output_mtok: 1.2
+```
+
+- Put the entry with no `constraint` **first**. Both engines scan the list backwards and take the
+  first entry whose constraint is active, so an unconstrained entry placed last would always win.
+- Set `start_date` to the date the provider's new price took effect, not to today. Cite the changelog
+  or announcement that states that date, in a YAML comment beside `start_date`.
+- Set `prices_checked` to today. It records when you verified the rates, which is a different fact
+  from when the rates changed.
+- Append one entry to a model that already uses a list. Leave the existing entries alone.
+
+Overwrite in place in exactly one case: the old value was wrong when it was written. A correction has
+no history worth preserving. State which of the two cases you are in, in the PR body.
+
+Verify both sides of the boundary:
+
+```bash
+uv run python -c "
+from datetime import datetime, timezone
+from genai_prices import calc_price, Usage
+u = Usage(input_tokens=1_000_000)
+for day in [(2026, 7, 29), (2026, 7, 30)]:
+    t = datetime(*day, tzinfo=timezone.utc)
+    r = calc_price(u, '<id>', provider_id='<provider_id>', genai_request_timestamp=t)
+    print(t.date(), '->', r.model_price.input_mtok, r.total_price)
+"
+```
+
+Then pin both sides in `tests/test_price_calc.py` — one assertion the day before the change, one on
+the day of. A test that only covers the current rate passes just as well against an overwritten
+history, which is why #531 went green.
 
 ## 5. Build + verify resolution
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,20 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
 
+# Frozen v1 compatibility snapshots. No build step writes these, so drift here is
+# invisible to the `build` hook; their contents are pinned by tests/test_frozen_v1_data.py.
 prices/data.json linguist-generated=true
 prices/data_slim.json linguist-generated=true
+prices/data.schema.json linguist-generated=true
+prices/data_slim.schema.json linguist-generated=true
 
+# Written by `make build`. The pre-commit `build` hook regenerates all of these and
+# fails when the result differs from what is committed.
 prices/new_data/v2/data.json linguist-generated=true
 prices/new_data/v2/data_slim.json linguist-generated=true
+prices/new_data/v2/data.schema.json linguist-generated=true
+prices/new_data/v2/data_slim.schema.json linguist-generated=true
+prices/providers/.schema.json linguist-generated=true
+packages/python/genai_prices/data.py linguist-generated=true
+packages/python/genai_prices/data_units.py linguist-generated=true
+packages/js/src/data.ts linguist-generated=true
+packages/js/src/dataUnits.ts linguist-generated=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,13 +101,17 @@ little, suspect the importer before the data.
 
 - **v2 is the live feed.** `prices/new_data/v2/data.json` is what the published packages auto-update
   from, and it goes live on merge to `main` — independent of any package release.
-- **v1 is frozen.** `prices/data.json` and `prices/data_slim.json` are compatibility snapshots for
-  pre-0.1.0 clients. No build step writes them any more, and they receive no provider, model or price
-  updates. Don't regenerate them, don't hand-edit them, and don't treat their stale `prices_checked`
-  dates as a bug.
+- **v1 is frozen.** `prices/data.json`, `prices/data_slim.json` and their two schemas are compatibility
+  snapshots for pre-0.1.0 clients. No build step writes them any more, and they receive no provider,
+  model or price updates. Don't regenerate them, don't hand-edit them, and don't treat their stale
+  `prices_checked` dates as a bug. `tests/test_frozen_v1_data.py` pins their sha256 digests, so an edit
+  fails the test suite — because no build step rewrites them, that test is the only thing that catches it.
 - **NEVER** hand-edit any generated file: the v2 payloads and schemas, `prices/providers/.schema.json`,
   or the bundled `data.py` / `data.ts` / `data_units.py` / `dataUnits.ts`. Edit the provider YAML or
-  `prices/units.yml` and run `make build`.
+  `prices/units.yml` and run `make build`. The pre-commit `build` hook regenerates all of these and
+  fails when the result differs, so CI catches an edit to any of them.
+- Every generated artifact is marked `linguist-generated` in `.gitattributes`, so GitHub collapses its
+  diff. Review the provider YAML and `units.yml`; trust the build hook and the digest test for the rest.
 - Published artifact URLs must not change — new contracts go in a new `prices/new_data/v<version>/`
   directory rather than moving or renaming existing files.
 - When updating prices in YAML files, always update the `prices_checked` field to current date

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,15 @@ little, suspect the importer before the data.
   diff. Review the provider YAML and `units.yml`; trust the build hook and the digest test for the rest.
 - Published artifact URLs must not change — new contracts go in a new `prices/new_data/v<version>/`
   directory rather than moving or renaming existing files.
+- **Never overwrite a `prices:` block when a provider changes its rates.** Editing those values in
+  place re-prices every past request at the new rate — a request from before the change gets billed
+  at today's price. Add a dated conditional price entry instead: make `prices:` a list, keep the
+  existing rates as the first entry with no `constraint`, and append the new rates under
+  `constraint: { start_date: <date the new price took effect> }`. Both engines take the **last**
+  matching entry, so the dated entry goes at the end. `openai.yml` (o3) and `anthropic.yml`
+  (1M-context surcharge) show the shape. Overwrite in place only to correct a value that was already
+  wrong when it was written — a correction has no history worth keeping. The `/add-price-model` skill
+  covers the full procedure.
 - When updating prices in YAML files, always update the `prices_checked` field to current date
 - Add `price_comments` to explain changes and provide references
 

--- a/tests/test_frozen_v1_data.py
+++ b/tests/test_frozen_v1_data.py
@@ -1,0 +1,30 @@
+import hashlib
+
+import pytest
+
+from prices.utils import package_dir as prices_package_dir
+
+# The v1 payloads and schemas are a frozen compatibility surface for pre-0.1.0 clients.
+# No build step writes them, so the pre-commit `build` hook — which is what catches drift
+# in every other generated artifact — cannot see an edit here. They are also marked
+# `linguist-generated`, so GitHub collapses their diffs and a reviewer is unlikely to look.
+# These digests are the check that replaces both. Updating one is a deliberate act that
+# shows up in this file's diff; new contracts belong in a new `prices/new_data/v<version>/`
+# directory instead.
+FROZEN_V1_DIGESTS = {
+    'data.json': 'f41075aab069a7dc378f83b7586523f72682a6c9860b23a89ad0b57c073aec41',
+    'data_slim.json': 'cca400c914ecd66dbb3c3f9e26fb66e5528a2986aeceed14b831361722cd4740',
+    'data.schema.json': '663171ade82700f8a07075f47a3548eeda4c732fa686f2e344a4a2045d25dd59',
+    'data_slim.schema.json': 'bf89de05d1b7fd9d977d6c9d7d1ffdeaca0a69fe14b6d355c31bb097bd530ce6',
+}
+
+
+@pytest.mark.parametrize(('filename', 'expected_digest'), sorted(FROZEN_V1_DIGESTS.items()))
+def test_frozen_v1_artifact_unchanged(filename: str, expected_digest: str) -> None:
+    path = prices_package_dir / filename
+
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == expected_digest, (
+        f'{filename} is a frozen v1 compatibility snapshot and must not change. '
+        'Publish new data under prices/new_data/ instead. If this edit really is '
+        'intentional, update the digest in FROZEN_V1_DIGESTS in the same commit.'
+    )


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David reviewed it lightly.

## Why

`.gitattributes` marked four generated files `linguist-generated`, so GitHub collapses their diffs. The other nine generated files were unmarked, and they dominate the reviewable diff of every price PR — #535 shows +162/−66 on `data.ts` and +64/−16 on `data.py` around a 94-line `openai.yml` change.

Marking the rest is only safe if CI, rather than a reviewer, is what verifies them. For everything `make build` writes, it already is: CI's `pre-commit` job runs `pre-commit run --all-files`, the local `build` hook regenerates all of it, and pre-commit fails when a hook modifies files. Verified by editing `packages/js/src/data.ts` and running the hook:

```
- hook id: build
- files were modified by this hook
```

## The gap this closes

That guarantee does **not** extend to the v1 snapshots, which were already collapsed. No build step writes them any more, so the `build` hook has nothing to compare against. Tampering with `prices/data.json` and running `make build` leaves the edit in place:

```
$ make build && git status --short
 M prices/data.json
```

Collapsed on GitHub, invisible to the build hook — an edit reaches `main` unchecked today.

`tests/test_frozen_v1_data.py` pins the sha256 of all four v1 artifacts (both payloads and both schemas — the schemas were never marked either, and are equally frozen). Confirmed to fail on a tampered payload:

```
AssertionError: data.json is a frozen v1 compatibility snapshot and must not change.
Publish new data under prices/new_data/ instead. If this edit really is intentional,
update the digest in FROZEN_V1_DIGESTS in the same commit.
```

The digests live in an ordinary test file, so a deliberate change has to appear in a diff nobody's tooling collapses.

## Changes

- `.gitattributes` — marks the nine remaining generated artifacts, grouped by what verifies each group, with that stated in comments
- `tests/test_frozen_v1_data.py` — sha256 pin for the four frozen v1 artifacts
- `AGENTS.md` — records what enforces what, so the next agent doesn't have to re-derive it

## Deliberate scope decisions

- **The v2 schema freeze is not addressed here.** `AGENTS.md` says adding a unit to `units.yml` silently widens the published v2 schema and that nothing blocks it. Still true — the `build` hook verifies the schema *matches* `units.yml`, which a widening does. That is a contract guard, not a tamper check, and is tracked separately in #540.
- **No JS test added.** The change is `.gitattributes`, a Python test, and docs; no JS behaviour is touched.
- **v1 artifacts left byte-identical.** The point is to pin them, not to refresh them.

## Verification

- `make lint`, `make typecheck` — pass
- `make test` — all pass, 100% coverage
- `tests/test_frozen_v1_data.py` — passes clean, fails on a tampered payload (shown above)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

