### PR TITLE
Prep 0.1.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7579,7 +7579,7 @@
     },
     "packages/js": {
       "name": "@pydantic/genai-prices",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "yargs": "^17.7.2"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/genai-prices",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Calculate prices for calling LLM inference APIs",
   "author": "Pydantic Team",
   "type": "module",

--- a/packages/js/src/cli.ts
+++ b/packages/js/src/cli.ts
@@ -5,6 +5,7 @@ import { hideBin } from 'yargs/helpers'
 
 import type { Provider } from './types'
 
+import { version } from '../package.json'
 import { data as embeddedData } from './data'
 import { calcPrice } from './index'
 
@@ -57,7 +58,7 @@ const argv = yargs(hideBin(process.argv))
   .option('requests', { type: 'number' })
   .option('provider', { type: 'string' })
   .option('timestamp', { describe: 'RFC3339 timestamp', type: 'string' })
-  .version('0.1.0')
+  .version(version)
   .help()
   .parseSync() as Argv
 

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "genai-prices"
-version = "0.1.0"
+version = "0.1.1"
 description = "Calculate prices for calling LLM inference APIs."
 readme = "README.md"
 authors = [{ name = "Samuel Colvin", email = "samuel@pydantic.dev" }]

--- a/uv.lock
+++ b/uv.lock
@@ -317,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/python" }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
Patch release carrying #544 (fix(js): normalize downloaded price constraints), which fixes the JS runtime throwing `Invalid time-of-day constraint: undefined` when auto-updating to the published v2 pricing data with conditional (`start_date` / time-of-day) prices. Malformed downloaded constraints are now rejected at activation while the previous active data keeps serving.

Per RELEASE.md: `./uprev.sh 0.1.1`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

