### PR TITLE
Fix Prettier configuration scope drift

### DIFF
--- a/.github/copilot/actions-setup-steps.yml
+++ b/.github/copilot/actions-setup-steps.yml
@@ -10,5 +10,5 @@ steps:
   - name: Setup Node.js
     uses: actions/setup-node@v4
     with:
-      node-version: '22.x'
-      cache: 'npm'
+      node-version: "22.x"
+      cache: "npm"

--- a/.github/workflows/after-ci.yml
+++ b/.github/workflows/after-ci.yml
@@ -16,12 +16,12 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
-          python-version: '3.12'
+          python-version: "3.12"
 
       - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           workflow: ci.yml
-          name: '(diff-)?coverage-html.*'
+          name: "(diff-)?coverage-html.*"
           name_is_regexp: true
           commit: ${{ github.event.workflow_run.head_sha }}
           allow_forks: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     tags:
-      - '**'
+      - "**"
   pull_request: {}
 
 permissions:
@@ -13,7 +13,7 @@ permissions:
 env:
   COLUMNS: 150
   UV_PYTHON: 3.13
-  UV_FROZEN: '1'
+  UV_FROZEN: "1"
 
 jobs:
   pre-commit:
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       UV_PYTHON: ${{ matrix.python-version }}
     runs-on: ubuntu-latest
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
-          cache: 'npm' # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
+          cache: "npm" # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
 
       - run: npm install
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,13 +45,13 @@ repos:
       - id: prettier
         name: prettier
         entry: npx
-        args: [--, prettier, --config, prettier.config.mjs, --write, --ignore-unknown]
+        args: [--, prettier, --write, --ignore-unknown]
         language: system
       - id: lint-fix
         name: lint fix
         entry: npm
         args: [run, lint-fix]
-        files: 'packages/js/'
+        files: "packages/js/"
         types_or: [ts, javascript]
         language: system
         pass_filenames: false
@@ -66,14 +66,14 @@ repos:
         name: collapse models
         entry: make
         args: [collapse-models]
-        files: 'prices/providers/'
+        files: "prices/providers/"
         language: system
         pass_filenames: false
       - id: build
         name: build prices
         entry: make
         args: [build]
-        files: 'prices/'
+        files: "prices/"
         language: system
         pass_filenames: false
       - id: check-for-price-discrepancies
@@ -81,7 +81,7 @@ repos:
         entry: make
         args: [check-for-price-discrepancies]
         types: [yaml]
-        files: 'prices/'
+        files: "prices/"
         language: system
         pass_filenames: false
       - id: inject-providers
@@ -89,7 +89,7 @@ repos:
         entry: make
         args: [inject-providers]
         types: [yaml]
-        files: 'prices/'
+        files: "prices/"
         language: system
         pass_filenames: false
       - id: typecheck-python

--- a/benchmarks/javascript/pricing.ts
+++ b/benchmarks/javascript/pricing.ts
@@ -3,7 +3,13 @@ import { performance } from 'node:perf_hooks'
 import process from 'node:process'
 import { parseArgs } from 'node:util'
 
-import type { ModelPrice, ModelPriceCalculationResult, PriceCalculationResult, Provider, Usage } from '../../packages/js/src/types'
+import type {
+  ModelPrice,
+  ModelPriceCalculationResult,
+  PriceCalculationResult,
+  Provider,
+  Usage,
+} from '../../packages/js/src/types'
 
 import { calcPrice as calcPricePublic, updatePrices } from '../../packages/js/src/api'
 import { calcPrice as calcPriceDirect } from '../../packages/js/src/engine'
@@ -44,10 +50,17 @@ function priceResult(result: PriceCalculationResult): ModelPriceCalculationResul
   }
 }
 
-function assertPriceResult(actual: ModelPriceCalculationResult, expected: ModelPriceCalculationResult, label: string): void {
+function assertPriceResult(
+  actual: ModelPriceCalculationResult,
+  expected: ModelPriceCalculationResult,
+  label: string,
+): void {
   for (const field of ['input_price', 'output_price', 'total_price'] as const) {
     const difference = Math.abs(actual[field] - expected[field])
-    assert.ok(difference <= Number.EPSILON, `${label} ${field} ${actual[field].toString()} != ${expected[field].toString()}`)
+    assert.ok(
+      difference <= Number.EPSILON,
+      `${label} ${field} ${actual[field].toString()} != ${expected[field].toString()}`,
+    )
   }
 }
 
@@ -139,7 +152,11 @@ function assertExpectedResults(benchmarkCase: BenchmarkCase): void {
     providerId: 'benchmark',
     timestamp: BENCHMARK_TIMESTAMP,
   })
-  assertPriceResult(priceResult(publicCalculation), benchmarkCase.expected, `${benchmarkCase.name} public result changed`)
+  assertPriceResult(
+    priceResult(publicCalculation),
+    benchmarkCase.expected,
+    `${benchmarkCase.name} public result changed`,
+  )
 }
 
 function runIterations(operation: () => unknown, iterations: number): void {
@@ -152,7 +169,7 @@ function measure(
   caseName: string,
   pathName: string,
   operation: () => unknown,
-  { iterations, samples, warmupIterations }: BenchmarkSettings
+  { iterations, samples, warmupIterations }: BenchmarkSettings,
 ): BenchmarkResult {
   runIterations(operation, warmupIterations)
 
@@ -200,7 +217,14 @@ function runBenchmarks(settings: BenchmarkSettings): BenchmarkResult[] {
 
   const results: BenchmarkResult[] = []
   for (const benchmarkCase of cases) {
-    results.push(measure(benchmarkCase.name, 'direct', () => calcPriceDirect(benchmarkCase.usage, benchmarkCase.modelPrice), settings))
+    results.push(
+      measure(
+        benchmarkCase.name,
+        'direct',
+        () => calcPriceDirect(benchmarkCase.usage, benchmarkCase.modelPrice),
+        settings,
+      ),
+    )
     results.push(
       measure(
         benchmarkCase.name,
@@ -210,8 +234,8 @@ function runBenchmarks(settings: BenchmarkSettings): BenchmarkResult[] {
             providerId: 'benchmark',
             timestamp: BENCHMARK_TIMESTAMP,
           }),
-        settings
-      )
+        settings,
+      ),
     )
   }
   return results
@@ -247,12 +271,12 @@ function main(): void {
 
   console.log(`Node ${process.version} (V8 ${process.versions.v8})`)
   console.log(
-    `iterations=${settings.iterations.toString()} samples=${settings.samples.toString()} warmup_iterations=${settings.warmupIterations.toString()}`
+    `iterations=${settings.iterations.toString()} samples=${settings.samples.toString()} warmup_iterations=${settings.warmupIterations.toString()}`,
   )
   console.log('case                                      path      median ns/op      min ns/op      max ns/op')
   for (const result of results) {
     console.log(
-      `${result.caseName.padEnd(41)} ${result.pathName.padEnd(7)} ${result.medianNsPerOp.toFixed(1).padStart(13)} ${result.minNsPerOp.toFixed(1).padStart(14)} ${result.maxNsPerOp.toFixed(1).padStart(14)}`
+      `${result.caseName.padEnd(41)} ${result.pathName.padEnd(7)} ${result.medianNsPerOp.toFixed(1).padStart(13)} ${result.minNsPerOp.toFixed(1).padStart(14)} ${result.maxNsPerOp.toFixed(1).padStart(14)}`,
     )
   }
 }

--- a/prices/providers/cerebras.yml
+++ b/prices/providers/cerebras.yml
@@ -35,7 +35,7 @@ models:
         - starts_with: cerebras:gpt-oss-120b
     context_window: 131072
     prices_checked: 2025-11-06
-    price_comments: 'Developer tier pricing. Free tier: 65k context, Paid tier: 131k context.'
+    price_comments: "Developer tier pricing. Free tier: 65k context, Paid tier: 131k context."
     prices:
       input_mtok: 0.35
       output_mtok: 0.75
@@ -53,7 +53,7 @@ models:
         - starts_with: cerebras:llama-3.3-70b
     context_window: 128000
     prices_checked: 2025-11-07
-    price_comments: 'Developer tier pricing. Free tier: 65k context, Paid tier: 128k context.'
+    price_comments: "Developer tier pricing. Free tier: 65k context, Paid tier: 128k context."
     prices:
       input_mtok: 0.85
       output_mtok: 1.20
@@ -71,7 +71,7 @@ models:
         - starts_with: cerebras:llama3.1-8b
     context_window: 32768
     prices_checked: 2025-11-07
-    price_comments: 'Developer tier pricing. Free tier: 8k context, Paid tier: 32k context.'
+    price_comments: "Developer tier pricing. Free tier: 8k context, Paid tier: 32k context."
     prices:
       input_mtok: 0.10
       output_mtok: 0.10
@@ -89,7 +89,7 @@ models:
         - starts_with: cerebras:qwen-3-32b
     context_window: 131072
     prices_checked: 2025-11-07
-    price_comments: 'Developer tier pricing. Free tier: 65k context, Paid tier: 131k context.'
+    price_comments: "Developer tier pricing. Free tier: 65k context, Paid tier: 131k context."
     prices:
       input_mtok: 0.40
       output_mtok: 0.80

--- a/prices/providers/cohere.yml
+++ b/prices/providers/cohere.yml
@@ -5,7 +5,7 @@ pricing_urls:
   - https://cohere.com/pricing
 api_pattern: 'https://api\.cohere\.(?:ai|com)'
 model_match:
-  starts_with: 'command-'
+  starts_with: "command-"
 provider_match:
   contains: cohere
 extractors:

--- a/prices/providers/google.yml
+++ b/prices/providers/google.yml
@@ -745,7 +745,8 @@ models:
 
   - id: gemini-3-pro-preview
     name: Gemini 3 Pro Preview
-    description: The best model in the world for multimodal understanding, and our most powerful agentic and vibe-coding
+    description:
+      The best model in the world for multimodal understanding, and our most powerful agentic and vibe-coding
       model yet.
     match:
       or:
@@ -872,7 +873,8 @@ models:
         - regex: '^gemini-3\.5-flash-\d'
     context_window: 1000000
     prices_checked: 2026-05-19
-    price_comments: See https://ai.google.dev/gemini-api/docs/pricing. Standard tier pricing shown; Batch and Flex tiers
+    price_comments:
+      See https://ai.google.dev/gemini-api/docs/pricing. Standard tier pricing shown; Batch and Flex tiers
       offer 50% discount on input/output.
     prices:
       input_mtok: 1.5

--- a/prices/providers/minimax.yml
+++ b/prices/providers/minimax.yml
@@ -11,11 +11,11 @@ price_comments: >-
   rate used by the international platform for current models.
 model_match:
   or:
-    - starts_with: 'MiniMax-M'
-    - starts_with: 'minimax-m'
-    - equals: 'minimax-01'
-    - equals: 'M2-her'
-    - equals: 'm2-her'
+    - starts_with: "MiniMax-M"
+    - starts_with: "minimax-m"
+    - equals: "minimax-01"
+    - equals: "M2-her"
+    - equals: "m2-her"
 extractors:
   # Anthropic-compatible endpoint (api.minimax.io/anthropic/v1/messages): Anthropic
   # accounting — input_tokens excludes cache, so add cache back to get total input.
@@ -71,7 +71,7 @@ models:
         - equals: M2-her
         - equals: m2-her
     context_window: 64000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.30
       output_mtok: 1.20
@@ -90,7 +90,7 @@ models:
         - equals: MiniMax-M2.5
         - equals: minimax-m2.5
     context_window: 204800
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.30
       cache_read_mtok: 0.03
@@ -103,10 +103,10 @@ models:
       MiniMax M2.1 highspeed variant (legacy) with higher throughput.
     match:
       or:
-        - contains: 'M2.1-highspeed'
-        - contains: 'm2.1-highspeed'
+        - contains: "M2.1-highspeed"
+        - contains: "m2.1-highspeed"
     context_window: 204800
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.60
       cache_read_mtok: 0.03
@@ -119,10 +119,10 @@ models:
       MiniMax M2.5 highspeed variant with higher throughput.
     match:
       or:
-        - contains: 'M2.5-highspeed'
-        - contains: 'm2.5-highspeed'
+        - contains: "M2.5-highspeed"
+        - contains: "m2.5-highspeed"
     context_window: 204800
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.60
       cache_read_mtok: 0.03
@@ -140,7 +140,7 @@ models:
         - equals: MiniMax-M2.7
         - equals: minimax-m2.7
     context_window: 204800
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.30
       cache_read_mtok: 0.06
@@ -153,10 +153,10 @@ models:
       MiniMax M2.7 highspeed variant with higher throughput.
     match:
       or:
-        - contains: 'M2.7-highspeed'
-        - contains: 'm2.7-highspeed'
+        - contains: "M2.7-highspeed"
+        - contains: "m2.7-highspeed"
     context_window: 204800
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.60
       cache_read_mtok: 0.06

--- a/prices/providers/moonshotai.yml
+++ b/prices/providers/moonshotai.yml
@@ -6,8 +6,8 @@ pricing_urls:
 api_pattern: 'https://api\.moonshot\.'
 model_match:
   or:
-    - starts_with: 'kimi'
-    - starts_with: 'moonshot'
+    - starts_with: "kimi"
+    - starts_with: "moonshot"
 provider_match:
   contains: moonshot
 extractors:
@@ -130,7 +130,7 @@ models:
     match:
       starts_with: kimi-k2.6
     context_window: 262144
-    prices_checked: '2026-05-22'
+    prices_checked: "2026-05-22"
     prices:
       input_mtok: 0.95
       cache_read_mtok: 0.16
@@ -145,8 +145,8 @@ models:
     match:
       equals: kimi-k2.7-code
     context_window: 262144
-    prices_checked: '2026-06-15'
-    price_comments: 'Ref: https://platform.kimi.ai/docs/pricing/chat-k27-code.md'
+    prices_checked: "2026-06-15"
+    price_comments: "Ref: https://platform.kimi.ai/docs/pricing/chat-k27-code.md"
     prices:
       input_mtok: 0.95
       cache_read_mtok: 0.19
@@ -160,8 +160,8 @@ models:
     match:
       equals: kimi-k3
     context_window: 1048576
-    prices_checked: '2026-07-16'
-    price_comments: 'Ref: https://platform.kimi.ai/docs/pricing/chat-k3.md'
+    prices_checked: "2026-07-16"
+    price_comments: "Ref: https://platform.kimi.ai/docs/pricing/chat-k3.md"
     prices:
       input_mtok: 3.00
       cache_read_mtok: 0.30

--- a/prices/providers/openai.yml
+++ b/prices/providers/openai.yml
@@ -11,8 +11,8 @@ pricing_urls:
 api_pattern: 'https://api\.openai\.com'
 model_match:
   or:
-    - starts_with: 'gpt-'
-    - regex: '^o[134]'
+    - starts_with: "gpt-"
+    - regex: "^o[134]"
 provider_match:
   contains: openai
 extractors:
@@ -187,26 +187,26 @@ models:
       input_mtok: 20
       output_mtok: 20
 
-  - id: 'ft:gpt-3.5-turbo-'
+  - id: "ft:gpt-3.5-turbo-"
     description: GPT-3.5 Turbo fine tuned.
     match:
-      starts_with: 'ft:gpt-3.5-turbo'
+      starts_with: "ft:gpt-3.5-turbo"
     prices:
       input_mtok: 3
       output_mtok: 6
 
-  - id: 'ft:gpt-4o'
+  - id: "ft:gpt-4o"
     description: GPT-4o fine tuned.
     match:
-      starts_with: 'ft:gpt-4o-2024-'
+      starts_with: "ft:gpt-4o-2024-"
     prices:
       input_mtok: 3.75
       output_mtok: 15
 
-  - id: 'ft:gpt-4o-mini'
+  - id: "ft:gpt-4o-mini"
     description: GPT-4o Mini fine tuned.
     match:
-      starts_with: 'ft:gpt-4o-mini-2024-'
+      starts_with: "ft:gpt-4o-mini-2024-"
     prices:
       input_mtok: 0.3
       output_mtok: 1.2

--- a/prices/providers/openrouter.yml
+++ b/prices/providers/openrouter.yml
@@ -46,9 +46,9 @@ models:
       input_mtok: 0.8
       output_mtok: 1.2
 
-  - id: 'agentica-org/deepcoder-14b-preview:free'
+  - id: "agentica-org/deepcoder-14b-preview:free"
     match:
-      equals: 'agentica-org/deepcoder-14b-preview:free'
+      equals: "agentica-org/deepcoder-14b-preview:free"
     prices: {}
 
   - id: ai21/jamba-1-5-large
@@ -140,9 +140,9 @@ models:
       input_mtok: 2.6
       output_mtok: 3.4
 
-  - id: 'allenai/molmo-7b-d:free'
+  - id: "allenai/molmo-7b-d:free"
     match:
-      equals: 'allenai/molmo-7b-d:free'
+      equals: "allenai/molmo-7b-d:free"
     prices: {}
 
   - id: allenai/olmo-3-32b-think
@@ -605,9 +605,9 @@ models:
       input_mtok: 0.45
       output_mtok: 0.75
 
-  - id: 'arliai/qwq-32b-arliai-rpr-v1:free'
+  - id: "arliai/qwq-32b-arliai-rpr-v1:free"
     match:
-      equals: 'arliai/qwq-32b-arliai-rpr-v1:free'
+      equals: "arliai/qwq-32b-arliai-rpr-v1:free"
     prices: {}
 
   - id: baidu/ernie-4.5-vl-424b-a47b
@@ -618,9 +618,9 @@ models:
       input_mtok: 0.42
       output_mtok: 1.25
 
-  - id: 'bytedance-research/ui-tars-72b:free'
+  - id: "bytedance-research/ui-tars-72b:free"
     match:
-      equals: 'bytedance-research/ui-tars-72b:free'
+      equals: "bytedance-research/ui-tars-72b:free"
     prices: {}
 
   - id: bytedance-seed/seed-1.6
@@ -789,14 +789,14 @@ models:
       input_mtok: 0.5
       output_mtok: 0.5
 
-  - id: 'cognitivecomputations/dolphin3.0-mistral-24b:free'
+  - id: "cognitivecomputations/dolphin3.0-mistral-24b:free"
     match:
-      equals: 'cognitivecomputations/dolphin3.0-mistral-24b:free'
+      equals: "cognitivecomputations/dolphin3.0-mistral-24b:free"
     prices: {}
 
-  - id: 'cognitivecomputations/dolphin3.0-r1-mistral-24b:free'
+  - id: "cognitivecomputations/dolphin3.0-r1-mistral-24b:free"
     match:
-      equals: 'cognitivecomputations/dolphin3.0-r1-mistral-24b:free'
+      equals: "cognitivecomputations/dolphin3.0-r1-mistral-24b:free"
     prices: {}
 
   - id: cohere/command
@@ -1024,9 +1024,9 @@ models:
       input_mtok: 0.3
       output_mtok: 0.88
 
-  - id: 'deepseek/deepseek-chat-v3-0324:free'
+  - id: "deepseek/deepseek-chat-v3-0324:free"
     match:
-      equals: 'deepseek/deepseek-chat-v3-0324:free'
+      equals: "deepseek/deepseek-chat-v3-0324:free"
     prices: {}
 
   - id: deepseek/deepseek-chat-v3.1
@@ -1038,9 +1038,9 @@ models:
       cache_read_mtok: 0.13
       output_mtok: 0.79
 
-  - id: 'deepseek/deepseek-chat:free'
+  - id: "deepseek/deepseek-chat:free"
     match:
-      equals: 'deepseek/deepseek-chat:free'
+      equals: "deepseek/deepseek-chat:free"
     prices: {}
 
   - id: deepseek/deepseek-r1
@@ -1067,9 +1067,9 @@ models:
       input_mtok: 0.1
       output_mtok: 0.4
 
-  - id: 'deepseek/deepseek-r1-distill-llama-70b:free'
+  - id: "deepseek/deepseek-r1-distill-llama-70b:free"
     match:
-      equals: 'deepseek/deepseek-r1-distill-llama-70b:free'
+      equals: "deepseek/deepseek-r1-distill-llama-70b:free"
     prices: {}
 
   - id: deepseek/deepseek-r1-distill-llama-8b
@@ -1093,9 +1093,9 @@ models:
       input_mtok: 0.15
       output_mtok: 0.15
 
-  - id: 'deepseek/deepseek-r1-distill-qwen-14b:free'
+  - id: "deepseek/deepseek-r1-distill-qwen-14b:free"
     match:
-      equals: 'deepseek/deepseek-r1-distill-qwen-14b:free'
+      equals: "deepseek/deepseek-r1-distill-qwen-14b:free"
     prices: {}
 
   - id: deepseek/deepseek-r1-distill-qwen-32b
@@ -1106,24 +1106,24 @@ models:
       input_mtok: 0.12
       output_mtok: 0.18
 
-  - id: 'deepseek/deepseek-r1-distill-qwen-32b:free'
+  - id: "deepseek/deepseek-r1-distill-qwen-32b:free"
     match:
-      equals: 'deepseek/deepseek-r1-distill-qwen-32b:free'
+      equals: "deepseek/deepseek-r1-distill-qwen-32b:free"
     prices: {}
 
-  - id: 'deepseek/deepseek-r1-zero:free'
+  - id: "deepseek/deepseek-r1-zero:free"
     match:
-      equals: 'deepseek/deepseek-r1-zero:free'
+      equals: "deepseek/deepseek-r1-zero:free"
     prices: {}
 
-  - id: 'deepseek/deepseek-r1:free'
+  - id: "deepseek/deepseek-r1:free"
     match:
-      equals: 'deepseek/deepseek-r1:free'
+      equals: "deepseek/deepseek-r1:free"
     prices: {}
 
-  - id: 'deepseek/deepseek-v3-base:free'
+  - id: "deepseek/deepseek-v3-base:free"
     match:
-      equals: 'deepseek/deepseek-v3-base:free'
+      equals: "deepseek/deepseek-v3-base:free"
     prices: {}
 
   - id: deepseek/deepseek-v3.1-terminus
@@ -1272,9 +1272,9 @@ models:
       input_mtok: 0.9
       output_mtok: 1.2
 
-  - id: 'featherless/qwerky-72b:free'
+  - id: "featherless/qwerky-72b:free"
     match:
-      equals: 'featherless/qwerky-72b:free'
+      equals: "featherless/qwerky-72b:free"
     prices: {}
 
   - id: fimbulvetr-11b-v2
@@ -1487,9 +1487,9 @@ models:
       input_mtok: 0.1
       output_mtok: 0.4
 
-  - id: 'google/gemini-2.0-flash-exp:free'
+  - id: "google/gemini-2.0-flash-exp:free"
     match:
-      equals: 'google/gemini-2.0-flash-exp:free'
+      equals: "google/gemini-2.0-flash-exp:free"
     prices: {}
 
   - id: google/gemini-2.0-flash-lite-001
@@ -1499,14 +1499,14 @@ models:
       input_mtok: 0.075
       output_mtok: 0.3
 
-  - id: 'google/gemini-2.0-flash-thinking-exp-1219:free'
+  - id: "google/gemini-2.0-flash-thinking-exp-1219:free"
     match:
-      equals: 'google/gemini-2.0-flash-thinking-exp-1219:free'
+      equals: "google/gemini-2.0-flash-thinking-exp-1219:free"
     prices: {}
 
-  - id: 'google/gemini-2.0-flash-thinking-exp:free'
+  - id: "google/gemini-2.0-flash-thinking-exp:free"
     match:
-      equals: 'google/gemini-2.0-flash-thinking-exp:free'
+      equals: "google/gemini-2.0-flash-thinking-exp:free"
     prices: {}
 
   - id: google/gemini-2.5-flash
@@ -1564,9 +1564,9 @@ models:
       cache_read_mtok: 0.075
       output_mtok: 2.50
 
-  - id: 'google/gemini-2.5-flash-preview:thinking'
+  - id: "google/gemini-2.5-flash-preview:thinking"
     match:
-      equals: 'google/gemini-2.5-flash-preview:thinking'
+      equals: "google/gemini-2.5-flash-preview:thinking"
     prices:
       input_mtok: 0.15
       output_mtok: 3.5
@@ -1584,9 +1584,9 @@ models:
       cache_read_mtok: 0.31
       output_mtok: 10
 
-  - id: 'google/gemini-2.5-pro-exp-03-25:free'
+  - id: "google/gemini-2.5-pro-exp-03-25:free"
     match:
-      equals: 'google/gemini-2.5-pro-exp-03-25:free'
+      equals: "google/gemini-2.5-pro-exp-03-25:free"
     prices: {}
 
   - id: google/gemini-2.5-pro-preview-03-25
@@ -1710,9 +1710,9 @@ models:
       input_mtok: 0.07
       output_mtok: 0.07
 
-  - id: 'google/gemma-2-9b-it:free'
+  - id: "google/gemma-2-9b-it:free"
     match:
-      equals: 'google/gemma-2-9b-it:free'
+      equals: "google/gemma-2-9b-it:free"
     prices: {}
 
   - id: google/gemma-3-12b-it
@@ -1723,14 +1723,14 @@ models:
       input_mtok: 0.05
       output_mtok: 0.1
 
-  - id: 'google/gemma-3-12b-it:free'
+  - id: "google/gemma-3-12b-it:free"
     match:
-      equals: 'google/gemma-3-12b-it:free'
+      equals: "google/gemma-3-12b-it:free"
     prices: {}
 
-  - id: 'google/gemma-3-1b-it:free'
+  - id: "google/gemma-3-1b-it:free"
     match:
-      equals: 'google/gemma-3-1b-it:free'
+      equals: "google/gemma-3-1b-it:free"
     prices: {}
 
   - id: google/gemma-3-27b-it
@@ -1741,9 +1741,9 @@ models:
       input_mtok: 0.1
       output_mtok: 0.2
 
-  - id: 'google/gemma-3-27b-it:free'
+  - id: "google/gemma-3-27b-it:free"
     match:
-      equals: 'google/gemma-3-27b-it:free'
+      equals: "google/gemma-3-27b-it:free"
     prices: {}
 
   - id: google/gemma-3-4b-it
@@ -1754,9 +1754,9 @@ models:
       input_mtok: 0.02
       output_mtok: 0.04
 
-  - id: 'google/gemma-3-4b-it:free'
+  - id: "google/gemma-3-4b-it:free"
     match:
-      equals: 'google/gemma-3-4b-it:free'
+      equals: "google/gemma-3-4b-it:free"
     prices: {}
 
   - id: google/gemma-3n-e4b-it
@@ -1796,9 +1796,9 @@ models:
       equals: google/gemma-4-31b-it:free
     prices: {}
 
-  - id: 'google/learnlm-1.5-pro-experimental:free'
+  - id: "google/learnlm-1.5-pro-experimental:free"
     match:
-      equals: 'google/learnlm-1.5-pro-experimental:free'
+      equals: "google/learnlm-1.5-pro-experimental:free"
     prices: {}
 
   - id: google/lyria-3-clip-preview
@@ -1933,9 +1933,9 @@ models:
       input_mtok: 0.025
       output_mtok: 0.04
 
-  - id: 'huggingfaceh4/zephyr-7b-beta:free'
+  - id: "huggingfaceh4/zephyr-7b-beta:free"
     match:
-      equals: 'huggingfaceh4/zephyr-7b-beta:free'
+      equals: "huggingfaceh4/zephyr-7b-beta:free"
     prices: {}
 
   - id: ibm-granite/granite-4.0-h-micro
@@ -2424,9 +2424,9 @@ models:
       input_mtok: 0.8
       output_mtok: 0.8
 
-  - id: 'meta-llama/llama-3.1-405b:free'
+  - id: "meta-llama/llama-3.1-405b:free"
     match:
-      equals: 'meta-llama/llama-3.1-405b:free'
+      equals: "meta-llama/llama-3.1-405b:free"
     prices: {}
 
   - id: meta-llama/llama-3.1-70b-instruct
@@ -2444,9 +2444,9 @@ models:
       input_mtok: 0.02
       output_mtok: 0.03
 
-  - id: 'meta-llama/llama-3.1-8b-instruct:free'
+  - id: "meta-llama/llama-3.1-8b-instruct:free"
     match:
-      equals: 'meta-llama/llama-3.1-8b-instruct:free'
+      equals: "meta-llama/llama-3.1-8b-instruct:free"
     prices: {}
 
   - id: meta-llama/llama-3.2-11b-vision-instruct
@@ -2457,9 +2457,9 @@ models:
       input_mtok: 0.049
       output_mtok: 0.049
 
-  - id: 'meta-llama/llama-3.2-11b-vision-instruct:free'
+  - id: "meta-llama/llama-3.2-11b-vision-instruct:free"
     match:
-      equals: 'meta-llama/llama-3.2-11b-vision-instruct:free'
+      equals: "meta-llama/llama-3.2-11b-vision-instruct:free"
     prices: {}
 
   - id: meta-llama/llama-3.2-1b-instruct
@@ -2470,9 +2470,9 @@ models:
       input_mtok: 0.005
       output_mtok: 0.01
 
-  - id: 'meta-llama/llama-3.2-1b-instruct:free'
+  - id: "meta-llama/llama-3.2-1b-instruct:free"
     match:
-      equals: 'meta-llama/llama-3.2-1b-instruct:free'
+      equals: "meta-llama/llama-3.2-1b-instruct:free"
     prices: {}
 
   - id: meta-llama/llama-3.2-3b-instruct
@@ -2518,9 +2518,9 @@ models:
       input_mtok: 0.15
       output_mtok: 0.6
 
-  - id: 'meta-llama/llama-4-maverick:free'
+  - id: "meta-llama/llama-4-maverick:free"
     match:
-      equals: 'meta-llama/llama-4-maverick:free'
+      equals: "meta-llama/llama-4-maverick:free"
     prices: {}
 
   - id: meta-llama/llama-4-scout
@@ -2531,9 +2531,9 @@ models:
       input_mtok: 0.08
       output_mtok: 0.3
 
-  - id: 'meta-llama/llama-4-scout:free'
+  - id: "meta-llama/llama-4-scout:free"
     match:
-      equals: 'meta-llama/llama-4-scout:free'
+      equals: "meta-llama/llama-4-scout:free"
     prices: {}
 
   - id: meta-llama/llama-guard-2-8b
@@ -2909,9 +2909,9 @@ models:
       input_mtok: 0.2
       output_mtok: 0.2
 
-  - id: 'mistralai/mistral-7b-instruct:free'
+  - id: "mistralai/mistral-7b-instruct:free"
     match:
-      equals: 'mistralai/mistral-7b-instruct:free'
+      equals: "mistralai/mistral-7b-instruct:free"
     prices: {}
 
   - id: mistralai/mistral-large
@@ -2974,9 +2974,9 @@ models:
       input_mtok: 0.01
       output_mtok: 0.019
 
-  - id: 'mistralai/mistral-nemo:free'
+  - id: "mistralai/mistral-nemo:free"
     match:
-      equals: 'mistralai/mistral-nemo:free'
+      equals: "mistralai/mistral-nemo:free"
     prices: {}
 
   - id: mistralai/mistral-saba
@@ -3002,9 +3002,9 @@ models:
       input_mtok: 0.05
       output_mtok: 0.09
 
-  - id: 'mistralai/mistral-small-24b-instruct-2501:free'
+  - id: "mistralai/mistral-small-24b-instruct-2501:free"
     match:
-      equals: 'mistralai/mistral-small-24b-instruct-2501:free'
+      equals: "mistralai/mistral-small-24b-instruct-2501:free"
     prices: {}
 
   - id: mistralai/mistral-small-2603
@@ -3024,9 +3024,9 @@ models:
       input_mtok: 0.05
       output_mtok: 0.15
 
-  - id: 'mistralai/mistral-small-3.1-24b-instruct:free'
+  - id: "mistralai/mistral-small-3.1-24b-instruct:free"
     match:
-      equals: 'mistralai/mistral-small-3.1-24b-instruct:free'
+      equals: "mistralai/mistral-small-3.1-24b-instruct:free"
     prices: {}
 
   - id: mistralai/mistral-small-3.2-24b-instruct
@@ -3168,8 +3168,8 @@ models:
         - equals: moonshotai/kimi-k2.7-code
         - equals: moonshotai/kimi-k2.7-code-20260612
     context_window: 262144
-    prices_checked: '2026-06-15'
-    price_comments: 'Ref: https://openrouter.ai/api/v1/models'
+    prices_checked: "2026-06-15"
+    price_comments: "Ref: https://openrouter.ai/api/v1/models"
     prices:
       input_mtok: 0.75
       cache_read_mtok: 0.16
@@ -3182,21 +3182,21 @@ models:
         - equals: moonshotai/kimi-k3
         - equals: moonshotai/kimi-k3-20260715
     context_window: 1048576
-    prices_checked: '2026-07-16'
-    price_comments: 'Ref: https://openrouter.ai/api/v1/models'
+    prices_checked: "2026-07-16"
+    price_comments: "Ref: https://openrouter.ai/api/v1/models"
     prices:
       input_mtok: 3.00
       cache_read_mtok: 0.30
       output_mtok: 15.00
 
-  - id: 'moonshotai/kimi-vl-a3b-thinking:free'
+  - id: "moonshotai/kimi-vl-a3b-thinking:free"
     match:
-      equals: 'moonshotai/kimi-vl-a3b-thinking:free'
+      equals: "moonshotai/kimi-vl-a3b-thinking:free"
     prices: {}
 
-  - id: 'moonshotai/moonlight-16b-a3b-instruct:free'
+  - id: "moonshotai/moonlight-16b-a3b-instruct:free"
     match:
-      equals: 'moonshotai/moonlight-16b-a3b-instruct:free'
+      equals: "moonshotai/moonlight-16b-a3b-instruct:free"
     prices: {}
 
   - id: morph/morph-v3-fast
@@ -3289,9 +3289,9 @@ models:
       input_mtok: 0.6
       output_mtok: 0.6
 
-  - id: 'nousresearch/deephermes-3-llama-3-8b-preview:free'
+  - id: "nousresearch/deephermes-3-llama-3-8b-preview:free"
     match:
-      equals: 'nousresearch/deephermes-3-llama-3-8b-preview:free'
+      equals: "nousresearch/deephermes-3-llama-3-8b-preview:free"
     prices: {}
 
   - id: nousresearch/hermes-2-pro-llama-3-8b
@@ -3360,19 +3360,19 @@ models:
       input_mtok: 0.12
       output_mtok: 0.3
 
-  - id: 'nvidia/llama-3.1-nemotron-70b-instruct:free'
+  - id: "nvidia/llama-3.1-nemotron-70b-instruct:free"
     match:
-      equals: 'nvidia/llama-3.1-nemotron-70b-instruct:free'
+      equals: "nvidia/llama-3.1-nemotron-70b-instruct:free"
     prices: {}
 
-  - id: 'nvidia/llama-3.1-nemotron-nano-8b-v1:free'
+  - id: "nvidia/llama-3.1-nemotron-nano-8b-v1:free"
     match:
-      equals: 'nvidia/llama-3.1-nemotron-nano-8b-v1:free'
+      equals: "nvidia/llama-3.1-nemotron-nano-8b-v1:free"
     prices: {}
 
-  - id: 'nvidia/llama-3.1-nemotron-ultra-253b-v1:free'
+  - id: "nvidia/llama-3.1-nemotron-ultra-253b-v1:free"
     match:
-      equals: 'nvidia/llama-3.1-nemotron-ultra-253b-v1:free'
+      equals: "nvidia/llama-3.1-nemotron-ultra-253b-v1:free"
     prices: {}
 
   - id: nvidia/llama-3.3-nemotron-super-49b-v1.5
@@ -3383,9 +3383,9 @@ models:
       input_mtok: 0.4
       output_mtok: 0.4
 
-  - id: 'nvidia/llama-3.3-nemotron-super-49b-v1:free'
+  - id: "nvidia/llama-3.3-nemotron-super-49b-v1:free"
     match:
-      equals: 'nvidia/llama-3.3-nemotron-super-49b-v1:free'
+      equals: "nvidia/llama-3.3-nemotron-super-49b-v1:free"
     prices: {}
 
   - id: nvidia/nemotron-3-nano-30b-a3b
@@ -3474,14 +3474,14 @@ models:
       cache_read_mtok: 0.55
       output_mtok: 4.4
 
-  - id: 'open-r1/olympiccoder-32b:free'
+  - id: "open-r1/olympiccoder-32b:free"
     match:
-      equals: 'open-r1/olympiccoder-32b:free'
+      equals: "open-r1/olympiccoder-32b:free"
     prices: {}
 
-  - id: 'open-r1/olympiccoder-7b:free'
+  - id: "open-r1/olympiccoder-7b:free"
     match:
-      equals: 'open-r1/olympiccoder-7b:free'
+      equals: "open-r1/olympiccoder-7b:free"
     prices: {}
 
   - id: openai/chatgpt-4o-latest
@@ -3658,9 +3658,9 @@ models:
       output_mtok: 10
     collapse: false
 
-  - id: 'openai/gpt-4o:extended'
+  - id: "openai/gpt-4o:extended"
     match:
-      equals: 'openai/gpt-4o:extended'
+      equals: "openai/gpt-4o:extended"
     prices:
       input_mtok: 6
       output_mtok: 18
@@ -4245,9 +4245,9 @@ models:
       input_mtok: 0.12
       output_mtok: 0.39
 
-  - id: 'qwen/qwen-2.5-72b-instruct:free'
+  - id: "qwen/qwen-2.5-72b-instruct:free"
     match:
-      equals: 'qwen/qwen-2.5-72b-instruct:free'
+      equals: "qwen/qwen-2.5-72b-instruct:free"
     prices: {}
 
   - id: qwen/qwen-2.5-7b-instruct
@@ -4258,9 +4258,9 @@ models:
       input_mtok: 0.04
       output_mtok: 0.1
 
-  - id: 'qwen/qwen-2.5-7b-instruct:free'
+  - id: "qwen/qwen-2.5-7b-instruct:free"
     match:
-      equals: 'qwen/qwen-2.5-7b-instruct:free'
+      equals: "qwen/qwen-2.5-7b-instruct:free"
     prices: {}
 
   - id: qwen/qwen-2.5-coder-32b-instruct
@@ -4271,9 +4271,9 @@ models:
       input_mtok: 0.06
       output_mtok: 0.15
 
-  - id: 'qwen/qwen-2.5-coder-32b-instruct:free'
+  - id: "qwen/qwen-2.5-coder-32b-instruct:free"
     match:
-      equals: 'qwen/qwen-2.5-coder-32b-instruct:free'
+      equals: "qwen/qwen-2.5-coder-32b-instruct:free"
     prices: {}
 
   - id: qwen/qwen-2.5-vl-72b-instruct
@@ -4290,9 +4290,9 @@ models:
       input_mtok: 0.2
       output_mtok: 0.2
 
-  - id: 'qwen/qwen-2.5-vl-7b-instruct:free'
+  - id: "qwen/qwen-2.5-vl-7b-instruct:free"
     match:
-      equals: 'qwen/qwen-2.5-vl-7b-instruct:free'
+      equals: "qwen/qwen-2.5-vl-7b-instruct:free"
     prices: {}
 
   - id: qwen/qwen-max
@@ -4363,14 +4363,14 @@ models:
       input_mtok: 0.9
       output_mtok: 0.9
 
-  - id: 'qwen/qwen2.5-vl-32b-instruct:free'
+  - id: "qwen/qwen2.5-vl-32b-instruct:free"
     match:
-      equals: 'qwen/qwen2.5-vl-32b-instruct:free'
+      equals: "qwen/qwen2.5-vl-32b-instruct:free"
     prices: {}
 
-  - id: 'qwen/qwen2.5-vl-3b-instruct:free'
+  - id: "qwen/qwen2.5-vl-3b-instruct:free"
     match:
-      equals: 'qwen/qwen2.5-vl-3b-instruct:free'
+      equals: "qwen/qwen2.5-vl-3b-instruct:free"
     prices: {}
 
   - id: qwen/qwen2.5-vl-72b-instruct
@@ -4380,9 +4380,9 @@ models:
       input_mtok: 0.7
       output_mtok: 0.7
 
-  - id: 'qwen/qwen2.5-vl-72b-instruct:free'
+  - id: "qwen/qwen2.5-vl-72b-instruct:free"
     match:
-      equals: 'qwen/qwen2.5-vl-72b-instruct:free'
+      equals: "qwen/qwen2.5-vl-72b-instruct:free"
     prices: {}
 
   - id: qwen/qwen3-14b
@@ -4782,14 +4782,14 @@ models:
       input_mtok: 0.2
       output_mtok: 0.2
 
-  - id: 'qwen/qwq-32b-preview:free'
+  - id: "qwen/qwq-32b-preview:free"
     match:
-      equals: 'qwen/qwq-32b-preview:free'
+      equals: "qwen/qwq-32b-preview:free"
     prices: {}
 
-  - id: 'qwen/qwq-32b:free'
+  - id: "qwen/qwq-32b:free"
     match:
-      equals: 'qwen/qwq-32b:free'
+      equals: "qwen/qwq-32b:free"
     prices: {}
 
   - id: qwen2.5-vl-32b-instruct
@@ -4913,9 +4913,9 @@ models:
       input_mtok: 0.1
       output_mtok: 0.2
 
-  - id: 'rekaai/reka-flash-3:free'
+  - id: "rekaai/reka-flash-3:free"
     match:
-      equals: 'rekaai/reka-flash-3:free'
+      equals: "rekaai/reka-flash-3:free"
     prices: {}
 
   - id: relace/relace-apply-3
@@ -5000,9 +5000,9 @@ models:
       input_mtok: 0.18
       output_mtok: 0.18
 
-  - id: 'shisa-ai/shisa-v2-llama3.3-70b:free'
+  - id: "shisa-ai/shisa-v2-llama3.3-70b:free"
     match:
-      equals: 'shisa-ai/shisa-v2-llama3.3-70b:free'
+      equals: "shisa-ai/shisa-v2-llama3.3-70b:free"
     prices: {}
 
   - id: shisa-v2-llama3.3-70b:free
@@ -5026,9 +5026,9 @@ models:
       input_mtok: 0.8
       output_mtok: 0.8
 
-  - id: 'sophosympatheia/rogue-rose-103b-v0.2:free'
+  - id: "sophosympatheia/rogue-rose-103b-v0.2:free"
     match:
-      equals: 'sophosympatheia/rogue-rose-103b-v0.2:free'
+      equals: "sophosympatheia/rogue-rose-103b-v0.2:free"
     prices: {}
 
   - id: sorcererlm-8x22b
@@ -5136,14 +5136,14 @@ models:
       input_mtok: 0.5
       output_mtok: 0.5
 
-  - id: 'thudm/glm-4-32b:free'
+  - id: "thudm/glm-4-32b:free"
     match:
-      equals: 'thudm/glm-4-32b:free'
+      equals: "thudm/glm-4-32b:free"
     prices: {}
 
-  - id: 'thudm/glm-z1-32b:free'
+  - id: "thudm/glm-z1-32b:free"
     match:
-      equals: 'thudm/glm-z1-32b:free'
+      equals: "thudm/glm-z1-32b:free"
     prices: {}
 
   - id: toppy-m-7b
@@ -5247,9 +5247,9 @@ models:
           - start: 128000
             price: 1.0
 
-  - id: 'x-ai/grok-4.1-fast:free'
+  - id: "x-ai/grok-4.1-fast:free"
     match:
-      equals: 'x-ai/grok-4.1-fast:free'
+      equals: "x-ai/grok-4.1-fast:free"
     context_window: 2000000
     prices: {}
 

--- a/prices/providers/voyageai.yml
+++ b/prices/providers/voyageai.yml
@@ -5,7 +5,7 @@ pricing_urls:
   - https://docs.voyageai.com/docs/pricing
 api_pattern: 'https://api\.voyageai\.com'
 model_match:
-  starts_with: 'voyage-'
+  starts_with: "voyage-"
 provider_match:
   contains: voyage
 price_comments: >-

--- a/prices/providers/zai.yml
+++ b/prices/providers/zai.yml
@@ -30,7 +30,7 @@ models:
         - equals: GLM-5.2
         - equals: glm-5.2
     context_window: 1000000
-    prices_checked: '2026-08-04'
+    prices_checked: "2026-08-04"
     prices:
       input_mtok: 1.4
       cache_read_mtok: 0.26

--- a/prices/providers/zhipuai.yml
+++ b/prices/providers/zhipuai.yml
@@ -16,8 +16,8 @@ price_comments: >-
   flagship models (limited-time promotion, not included).
 model_match:
   or:
-    - starts_with: 'GLM-'
-    - starts_with: 'glm-'
+    - starts_with: "GLM-"
+    - starts_with: "glm-"
 extractors:
   - api_flavor: chat
     root: usage
@@ -41,7 +41,7 @@ models:
         - equals: GLM-4-Air
         - equals: glm-4-air
     context_window: 128000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.069
       cache_read_mtok: 0.034
@@ -57,7 +57,7 @@ models:
         - equals: GLM-4-AirX
         - equals: glm-4-airx
     context_window: 8000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 1.379
       output_mtok: 1.379
@@ -72,7 +72,7 @@ models:
         - equals: GLM-4-Assistant
         - equals: glm-4-assistant
     context_window: 128000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.690
       output_mtok: 0.690
@@ -87,7 +87,7 @@ models:
         - equals: GLM-4-FlashX-250414
         - equals: glm-4-flashx-250414
     context_window: 128000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.014
       cache_read_mtok: 0.007
@@ -103,7 +103,7 @@ models:
         - equals: GLM-4-Long
         - equals: glm-4-long
     context_window: 1000000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.138
       cache_read_mtok: 0.069
@@ -119,7 +119,7 @@ models:
         - equals: GLM-4-Plus
         - equals: glm-4-plus
     context_window: 128000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.690
       cache_read_mtok: 0.345
@@ -136,7 +136,7 @@ models:
         - equals: GLM-4.5-Air
         - equals: glm-4.5-air
     context_window: 128000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.110
       cache_read_mtok: 0.022
@@ -152,7 +152,7 @@ models:
         - equals: GLM-4.7
         - equals: glm-4.7
     context_window: 200000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.276
       cache_read_mtok: 0.055
@@ -168,7 +168,7 @@ models:
         - equals: GLM-4.7-FlashX
         - equals: glm-4.7-flashx
     context_window: 200000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.069
       cache_read_mtok: 0.014
@@ -184,7 +184,7 @@ models:
         - equals: GLM-5
         - equals: glm-5
     context_window: 200000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.552
       cache_read_mtok: 0.138
@@ -200,7 +200,7 @@ models:
         - equals: GLM-5-Turbo
         - equals: glm-5-turbo
     context_window: 200000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.690
       cache_read_mtok: 0.166
@@ -219,7 +219,7 @@ models:
         - equals: GLM-5.1-20260406
         - equals: glm-5.1-20260406
     context_window: 200000
-    prices_checked: '2026-05-23'
+    prices_checked: "2026-05-23"
     prices:
       input_mtok: 0.828
       cache_read_mtok: 0.179
@@ -235,7 +235,7 @@ models:
         - equals: GLM-5.2
         - equals: glm-5.2
     context_window: 1000000
-    prices_checked: '2026-06-17'
+    prices_checked: "2026-06-17"
     prices:
       input_mtok: 1.103
       cache_read_mtok: 0.276

--- a/prices/src/prices/package_data.py
+++ b/prices/src/prices/package_data.py
@@ -192,8 +192,6 @@ export const unitData: RawUnitsDict = {json.dumps(runtime_units, indent=2, ensur
             'npx',
             '--',
             'prettier',
-            '--config',
-            '../../prettier.config.mjs',
             '--write',
             'src/data.ts',
             'src/dataUnits.ts',

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -840,6 +840,7 @@ def test_package_ts_data_accepts_separated_inputs_without_units_yml(
     js_src_dir = tmp_path / 'packages' / 'js' / 'src'
     js_src_dir.mkdir(parents=True)
     monkeypatch.setattr(package_data, 'root_dir', tmp_path)
+    prettier_calls: list[tuple[list[str], str | None]] = []
 
     def skip_prettier(
         args: list[str],
@@ -848,7 +849,8 @@ def test_package_ts_data_accepts_separated_inputs_without_units_yml(
         check: bool = False,
         stdout: int | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        _ = cwd, check, stdout
+        _ = check, stdout
+        prettier_calls.append((args, cwd))
         return subprocess.CompletedProcess(args, 0)
 
     monkeypatch.setattr(subprocess, 'run', skip_prettier)
@@ -865,6 +867,12 @@ def test_package_ts_data_accepts_separated_inputs_without_units_yml(
             'dimensions': {'family': 'tokens', 'direction': 'input'},
         }
     }
+    assert prettier_calls == [
+        (
+            ['npx', '--', 'prettier', '--write', 'src/data.ts', 'src/dataUnits.ts'],
+            str(tmp_path / 'packages' / 'js'),
+        )
+    ]
 
 
 def test_build_model_price_accepts_typed_extra_price_keys() -> None:


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-terra on behalf of David.

Restores the intended per-file Prettier configuration lookup.

- Pre-commit now discovers configuration from each formatted file instead of forcing the JS/root MJS configuration.
- TypeScript data generation runs Prettier from the JS package and uses its local configuration through discovery.
- Adds a regression assertion for that generator invocation.
- Normalizes the root/YAML files that #552 had formatted with the wrong configuration.

The root/YAML configuration remains in `package.json`; JavaScript continues to use `packages/js/prettier.config.mjs`.

Validation: `pre-commit run --all-files --verbose`, `make test` (100% coverage), `npm run ci`, and `npm run format` all pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

