### PR TITLE
Prep 0.1.3 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7579,7 +7579,7 @@
     },
     "packages/js": {
       "name": "@pydantic/genai-prices",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "yargs": "^17.7.2"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/genai-prices",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Calculate prices for calling LLM inference APIs",
   "author": "Pydantic Team",
   "type": "module",

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "genai-prices"
-version = "0.1.2"
+version = "0.1.3"
 description = "Calculate prices for calling LLM inference APIs."
 readme = "README.md"
 authors = [{ name = "Samuel Colvin", email = "samuel@pydantic.dev" }]

--- a/uv.lock
+++ b/uv.lock
@@ -317,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "packages/python" }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
## Summary

- bump the Python package to 0.1.3
- bump the JavaScript package and both lockfile workspace entries to 0.1.3

This intentionally matches the minimal four-file shape of recent release PRs.

## Validation

- `uv lock --check`
- pre-commit hooks
- `make all`
- `npm run ci`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

