### PR TITLE
Reject mapping usage inputs instead of pricing them at zero

### DIFF
--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -222,9 +222,12 @@ class Usage:
         # would price at zero however many tokens it names. Mappings are not a
         # supported usage input, so say so rather than undercharge silently.
         if isinstance(obj, Mapping):
+            # isinstance narrows to Mapping[Unknown, Unknown], so name the type through a
+            # cast to keep the type checker from seeing partially unknown arguments.
+            unsupported = cast('Mapping[Any, Any]', obj)
             raise TypeError(
                 'Mappings are not supported as usage input. '
-                f'Pass a Usage instance or an object with usage attributes, not {type(obj).__name__}.'
+                f'Pass a Usage instance or an object with usage attributes, not {type(unsupported).__name__}.'
             )
 
         values: dict[str, UsageValue] = {}

--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -218,6 +218,15 @@ class Usage:
             obj._reported_values()
             return obj
 
+        # Usage values are read with getattr, so a mapping contributes nothing and
+        # would price at zero however many tokens it names. Mappings are not a
+        # supported usage input, so say so rather than undercharge silently.
+        if isinstance(obj, Mapping):
+            raise TypeError(
+                'Mappings are not supported as usage input. '
+                f'Pass a Usage instance or an object with usage attributes, not {type(obj).__name__}.'
+            )
+
         values: dict[str, UsageValue] = {}
         for key in _reported_usage_keys():
             value = _raw_usage_value(obj, key)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
-from genai_prices.types import Usage
+from genai_prices.types import ModelPrice, Usage
 from genai_prices.units import UnitRegistry
 
 
@@ -279,10 +279,21 @@ def test_usage_repr_orders_extra_registered_keys_by_registry_order() -> None:
         assert repr(usage) == 'Usage(input_tokens=3, sausage_tokens=1, cheese_tokens=2)'
 
 
-def test_usage_from_raw_ignores_mapping_keys() -> None:
-    usage = Usage.from_raw({'input_tokens': 100, 'output_tokens': 50})
+def test_usage_from_raw_rejects_mappings() -> None:
+    # A mapping used to price at zero however many tokens it named, because usage
+    # values are read with getattr. Unsupported input has to say so.
+    with pytest.raises(TypeError, match='Mappings are not supported'):
+        Usage.from_raw({'input_tokens': 100, 'output_tokens': 50})
 
-    assert usage == Usage()
+
+def test_calc_price_rejects_mapping_instead_of_pricing_it_at_zero() -> None:
+    price = ModelPrice(input_mtok=Decimal('1'))
+
+    with pytest.raises(TypeError, match='Mappings are not supported'):
+        price.calc_price({'input_tokens': 1_000_000})
+
+    # The same usage as an object still prices, so only the unsupported shape changed.
+    assert price.calc_price(SimpleNamespace(input_tokens=1_000_000))['total_price'] == Decimal('1')
 
 
 def test_usage_from_raw_reads_known_object_attributes() -> None:


### PR DESCRIPTION
Fixes #516.

## What happens now

On current main the same usage prices differently depending on its shape:

```python
price = ModelPrice(input_mtok=Decimal('1'))

price.calc_price({'input_tokens': 1_000_000})                      # 0
price.calc_price(SimpleNamespace(input_tokens=1_000_000))          # 1
```

A million input tokens costs nothing if you pass a dict, because `Usage.from_raw` reads values with `getattr` and a mapping has no such attributes, so it builds an empty `Usage` and everything downstream prices honestly against nothing.

## The change

`Usage.from_raw` now raises `TypeError` for mappings, naming the type it received. That is the second option in the issue, rejecting rather than supporting mapping keys, since mapping compatibility is out of scope.

The blast radius is small: `from_raw` has one internal caller, `ModelPrice.calc_price`, so the only behaviour that changes is an input that previously produced a silent undercharge.

## About the existing test

`test_usage_from_raw_ignores_mapping_keys` asserted the current behaviour, so I replaced it rather than worked around it. In its place:

- `test_usage_from_raw_rejects_mappings`, the same input now expecting the `TypeError`
- `test_calc_price_rejects_mapping_instead_of_pricing_it_at_zero`, which pairs the rejection with the assertion that the same usage as an object still prices at 1, so only the unsupported shape changed

Both fail on main.

## One thing I noticed, for your call rather than mine

The JS package types usage as `Record<string, number | undefined>`, so a plain object is its native and only usage input and the same `{input_tokens: 1_000_000}` prices correctly there. Since `AGENTS.md` says the two implementations must stay behaviourally identical, this fix makes Python raise where JS accepts. That seemed like the right reading of the issue, which scopes mapping support out for Python, but if you would rather close the gap the other way I am happy to redo it as mapping support instead.

## Tests

`tests/test_usage.py` 48 passed, and the suites that collect in a plain venv here are green: `test_extract_usage` 74, `test_decompose` 20, `test_custom_prices` 11, `test_lifecycle` 11, `test_end_to_end` 7. I could not run the data-pipeline suites locally, they need the `prices` build tooling.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

