### PR TITLE
Cache provider resolution in data snapshots

### DIFF
--- a/packages/python/genai_prices/data_snapshot.py
+++ b/packages/python/genai_prices/data_snapshot.py
@@ -42,7 +42,7 @@ class DataSnapshot:
     _lookup_cache: dict[tuple[str | None, str | None, str], tuple[types.Provider, types.ModelInfo]] = field(
         default_factory=lambda: {}
     )
-    _provider_cache: dict[tuple[str | None, str | None, str | None], types.Provider | None] = field(
+    _provider_cache: dict[tuple[str | None, str | None, str | None], types.Provider | str] = field(
         default_factory=lambda: {}, init=False
     )
     timestamp: datetime = field(default_factory=datetime.now)
@@ -127,35 +127,39 @@ class DataSnapshot:
         provider_api_url: str | None,
     ) -> types.Provider:
         cache_key = (model_ref, provider_id, provider_api_url)
-        if cache_key in self._provider_cache:
-            provider = self._provider_cache[cache_key]
-        else:
-            provider = find_provider_by_id(self.providers, provider_id) if provider_id is not None else None
-            allow_fallback = provider_id is None or provider_id.lower() == 'litellm'
+        cached = self._provider_cache.get(cache_key)
+        if isinstance(cached, str):
+            raise LookupError(cached)
+        if cached is not None:
+            return cached
 
-            if provider is None and allow_fallback and provider_api_url is not None:
-                provider = next(
-                    (provider for provider in self.providers if re.match(provider.api_pattern, provider_api_url)), None
-                )
-            elif provider is None and allow_fallback and model_ref:
-                provider = next(
-                    (
-                        provider
-                        for provider in self.providers
-                        if provider.model_match is not None and provider.model_match.is_match(model_ref)
-                    ),
-                    None,
-                )
+        if provider_id is not None:
+            if provider := find_provider_by_id(self.providers, provider_id):
+                self._provider_cache[cache_key] = provider
+                return provider
+            if provider_id.lower() != 'litellm':
+                error = f'Unable to find provider {provider_id=!r}'
+                self._provider_cache[cache_key] = error
+                raise LookupError(error)
 
-            self._provider_cache[cache_key] = provider
-
-        if provider is not None:
-            return provider
-        if provider_id is not None and provider_id.lower() != 'litellm':
-            raise LookupError(f'Unable to find provider {provider_id=!r}')
         if provider_api_url is not None:
-            raise LookupError(f'Unable to find provider {provider_api_url=!r}')
-        raise LookupError(f'Unable to find provider with model matching {model_ref!r}')
+            for provider in self.providers:
+                if re.match(provider.api_pattern, provider_api_url):
+                    self._provider_cache[cache_key] = provider
+                    return provider
+            error = f'Unable to find provider {provider_api_url=!r}'
+            self._provider_cache[cache_key] = error
+            raise LookupError(error)
+
+        if model_ref:
+            for provider in self.providers:
+                if provider.model_match is not None and provider.model_match.is_match(model_ref):
+                    self._provider_cache[cache_key] = provider
+                    return provider
+
+        error = f'Unable to find provider with model matching {model_ref!r}'
+        self._provider_cache[cache_key] = error
+        raise LookupError(error)
 
 
 def find_provider_by_id(providers: list[types.Provider], provider_id: str) -> types.Provider | None:

--- a/packages/python/genai_prices/data_snapshot.py
+++ b/packages/python/genai_prices/data_snapshot.py
@@ -42,9 +42,10 @@ class DataSnapshot:
     _lookup_cache: dict[tuple[str | None, str | None, str], tuple[types.Provider, types.ModelInfo]] = field(
         default_factory=lambda: {}
     )
-    _provider_cache: dict[tuple[str | None, str | None, str | None], types.Provider | str] = field(
+    _provider_cache: dict[tuple[str | None, str | None, str | None], types.Provider] = field(
         default_factory=lambda: {}, init=False
     )
+    _provider_misses: set[tuple[str | None, str | None, str | None]] = field(default_factory=set, init=False)
     timestamp: datetime = field(default_factory=datetime.now)
 
     def active(self, ttl: timedelta) -> bool:
@@ -127,29 +128,26 @@ class DataSnapshot:
         provider_api_url: str | None,
     ) -> types.Provider:
         cache_key = (model_ref, provider_id, provider_api_url)
-        cached = self._provider_cache.get(cache_key)
-        if isinstance(cached, str):
-            raise LookupError(cached)
-        if cached is not None:
-            return cached
+        if provider := self._provider_cache.get(cache_key):
+            return provider
+        if cache_key in self._provider_misses:
+            raise _provider_lookup_error(model_ref, provider_id, provider_api_url)
 
         if provider_id is not None:
             if provider := find_provider_by_id(self.providers, provider_id):
                 self._provider_cache[cache_key] = provider
                 return provider
             if provider_id.lower() != 'litellm':
-                error = f'Unable to find provider {provider_id=!r}'
-                self._provider_cache[cache_key] = error
-                raise LookupError(error)
+                self._provider_misses.add(cache_key)
+                raise _provider_lookup_error(model_ref, provider_id, provider_api_url)
 
         if provider_api_url is not None:
             for provider in self.providers:
                 if re.match(provider.api_pattern, provider_api_url):
                     self._provider_cache[cache_key] = provider
                     return provider
-            error = f'Unable to find provider {provider_api_url=!r}'
-            self._provider_cache[cache_key] = error
-            raise LookupError(error)
+            self._provider_misses.add(cache_key)
+            raise _provider_lookup_error(model_ref, provider_id, provider_api_url)
 
         if model_ref:
             for provider in self.providers:
@@ -157,9 +155,8 @@ class DataSnapshot:
                     self._provider_cache[cache_key] = provider
                     return provider
 
-        error = f'Unable to find provider with model matching {model_ref!r}'
-        self._provider_cache[cache_key] = error
-        raise LookupError(error)
+        self._provider_misses.add(cache_key)
+        raise _provider_lookup_error(model_ref, provider_id, provider_api_url)
 
 
 def find_provider_by_id(providers: list[types.Provider], provider_id: str) -> types.Provider | None:
@@ -183,3 +180,11 @@ def find_provider_by_id(providers: list[types.Provider], provider_id: str) -> ty
             return provider
 
     return None
+
+
+def _provider_lookup_error(model_ref: str | None, provider_id: str | None, provider_api_url: str | None) -> LookupError:
+    if provider_id is not None and provider_id.lower() != 'litellm':
+        return LookupError(f'Unable to find provider {provider_id=!r}')
+    if provider_api_url is not None:
+        return LookupError(f'Unable to find provider {provider_api_url=!r}')
+    return LookupError(f'Unable to find provider with model matching {model_ref!r}')

--- a/packages/python/genai_prices/data_snapshot.py
+++ b/packages/python/genai_prices/data_snapshot.py
@@ -42,6 +42,9 @@ class DataSnapshot:
     _lookup_cache: dict[tuple[str | None, str | None, str], tuple[types.Provider, types.ModelInfo]] = field(
         default_factory=lambda: {}
     )
+    _provider_cache: dict[tuple[str | None, str | None, str | None], types.Provider | None] = field(
+        default_factory=lambda: {}
+    )
     timestamp: datetime = field(default_factory=datetime.now)
 
     def active(self, ttl: timedelta) -> bool:
@@ -123,24 +126,35 @@ class DataSnapshot:
         provider_id: str | None,
         provider_api_url: str | None,
     ) -> types.Provider:
-        if provider_id is not None:
-            if provider := find_provider_by_id(self.providers, provider_id):
-                return provider
-            # Special case for litellm: fall back to model matching if provider not found
-            if provider_id.lower() != 'litellm':
-                raise LookupError(f'Unable to find provider {provider_id=!r}')
+        cache_key = (model_ref, provider_id, provider_api_url)
+        if cache_key in self._provider_cache:
+            provider = self._provider_cache[cache_key]
+        else:
+            provider = find_provider_by_id(self.providers, provider_id) if provider_id is not None else None
+            allow_fallback = provider_id is None or provider_id.lower() == 'litellm'
 
+            if provider is None and allow_fallback and provider_api_url is not None:
+                provider = next(
+                    (provider for provider in self.providers if re.match(provider.api_pattern, provider_api_url)), None
+                )
+            elif provider is None and allow_fallback and model_ref:
+                provider = next(
+                    (
+                        provider
+                        for provider in self.providers
+                        if provider.model_match is not None and provider.model_match.is_match(model_ref)
+                    ),
+                    None,
+                )
+
+            self._provider_cache[cache_key] = provider
+
+        if provider is not None:
+            return provider
+        if provider_id is not None and provider_id.lower() != 'litellm':
+            raise LookupError(f'Unable to find provider {provider_id=!r}')
         if provider_api_url is not None:
-            for provider in self.providers:
-                if re.match(provider.api_pattern, provider_api_url):
-                    return provider
             raise LookupError(f'Unable to find provider {provider_api_url=!r}')
-
-        if model_ref:
-            for provider in self.providers:
-                if provider.model_match is not None and provider.model_match.is_match(model_ref):
-                    return provider
-
         raise LookupError(f'Unable to find provider with model matching {model_ref!r}')
 
 

--- a/packages/python/genai_prices/data_snapshot.py
+++ b/packages/python/genai_prices/data_snapshot.py
@@ -43,7 +43,7 @@ class DataSnapshot:
         default_factory=lambda: {}
     )
     _provider_cache: dict[tuple[str | None, str | None, str | None], types.Provider | None] = field(
-        default_factory=lambda: {}
+        default_factory=lambda: {}, init=False
     )
     timestamp: datetime = field(default_factory=datetime.now)
 

--- a/tests/test_model_matching.py
+++ b/tests/test_model_matching.py
@@ -706,6 +706,50 @@ def test_lookup_with_resolved_provider_is_cached(monkeypatch: pytest.MonkeyPatch
     find_model.assert_called_once_with(SHARED_MODEL_REF, all_providers=providers)
 
 
+def test_find_provider_caches_successful_resolution():
+    model_match = Mock()
+    model_match.is_match.return_value = True
+    provider = replace(providers[0], model_match=model_match)
+    snapshot = DataSnapshot(providers=[provider], from_auto_update=False)
+
+    assert snapshot.find_provider('cached-model', None, None) is provider
+    assert snapshot.find_provider('cached-model', None, None) is provider
+
+    model_match.is_match.assert_called_once_with('cached-model')
+
+
+def test_find_provider_caches_failed_resolution():
+    model_match = Mock()
+    model_match.is_match.return_value = False
+    provider = replace(providers[0], model_match=model_match)
+    snapshot = DataSnapshot(providers=[provider], from_auto_update=False)
+
+    for _ in range(2):
+        with pytest.raises(LookupError, match="Unable to find provider with model matching 'missing-model'"):
+            snapshot.find_provider('missing-model', None, None)
+
+    model_match.is_match.assert_called_once_with('missing-model')
+
+
+def test_find_provider_cache_is_isolated_by_snapshot():
+    missing_match = Mock()
+    missing_match.is_match.return_value = False
+    missing_provider = replace(providers[0], model_match=missing_match)
+    missing_snapshot = DataSnapshot(providers=[missing_provider], from_auto_update=False)
+
+    matching_match = Mock()
+    matching_match.is_match.return_value = True
+    matching_provider = replace(providers[0], model_match=matching_match)
+    matching_snapshot = DataSnapshot(providers=[matching_provider], from_auto_update=False)
+
+    with pytest.raises(LookupError, match="Unable to find provider with model matching 'snapshot-model'"):
+        missing_snapshot.find_provider('snapshot-model', None, None)
+
+    assert matching_snapshot.find_provider('snapshot-model', None, None) is matching_provider
+    missing_match.is_match.assert_called_once_with('snapshot-model')
+    matching_match.is_match.assert_called_once_with('snapshot-model')
+
+
 def test_snapshot_active_uses_ttl():
     snapshot = DataSnapshot(
         providers=providers, from_auto_update=False, timestamp=datetime.now() - timedelta(seconds=5)


### PR DESCRIPTION
Cache successful and failed provider resolutions on each `DataSnapshot`. This avoids repeated provider scans while ensuring replacement snapshots start with empty caches.

Closes #494.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

