### PR TITLE
Document aggregate cached input usage

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -26,6 +26,35 @@ if (result) {
 }
 ```
 
+### Cached input tokens
+
+```ts
+import { calcPrice } from '@pydantic/genai-prices'
+
+const result = calcPrice(
+  {
+    input_tokens: 4740,
+    cache_read_tokens: 0,
+    cache_write_tokens: 4735,
+    output_tokens: 255,
+  },
+  'claude-sonnet-4-20250514',
+  { providerId: 'anthropic' }
+)
+
+if (!result) {
+  throw new Error('No price found for claude-sonnet-4-20250514')
+}
+
+console.log(result.total_price)
+```
+
+`input_tokens` is the total number of input tokens. It includes uncached tokens, cache-read tokens, and cache-write
+tokens. You also report `cache_read_tokens` and `cache_write_tokens` so that `calcPrice` can apply their separate rates.
+
+Do not pass only the uncached count as `input_tokens`. Cache tokens are partitions of the total, so their combined count
+cannot exceed `input_tokens`.
+
 ### Fractional usage values
 
 Every reportable usage unit accepts finite non-negative numbers, including fractions. This is useful for duration units

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -51,6 +51,30 @@ price_data = calc_price(
 print(f"Total Price: ${price_data.total_price} (input: ${price_data.input_price}, output: ${price_data.output_price})")
 ```
 
+### Cached input tokens
+
+```python
+from genai_prices import Usage, calc_price
+
+price_data = calc_price(
+    Usage(
+        input_tokens=4740,
+        cache_read_tokens=0,
+        cache_write_tokens=4735,
+        output_tokens=255,
+    ),
+    model_ref='claude-sonnet-4-20250514',
+    provider_id='anthropic',
+)
+print(price_data.total_price)
+```
+
+`input_tokens` is the total number of input tokens. It includes uncached tokens, cache-read tokens, and cache-write
+tokens. You also report `cache_read_tokens` and `cache_write_tokens` so that `calc_price` can apply their separate rates.
+
+Do not pass only the uncached count as `input_tokens`. Cache tokens are partitions of the total, so their combined count
+cannot exceed `input_tokens`.
+
 ### `extract_usage`
 
 `extract_usage` can be used to extract usage data and the `model_ref` from response data,


### PR DESCRIPTION
## Summary

- explain that `input_tokens` includes uncached, cache-read, and cache-write tokens
- add runnable Python and JavaScript examples with cache-write usage
- clarify that cache counts are partitions of the aggregate input count

Closes #334.

## Verification

- ran the Python example with `uv run --package genai-prices python`
- ran the JavaScript example with `npx tsx`
- both examples produced `0.02159625`
- pre-commit hooks passed

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

