### PR TITLE
Replace yargs with Node argument parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1994,23 +1994,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/yargs": {
-      "version": "17.0.33",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.0.tgz",
@@ -2946,6 +2929,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2955,6 +2939,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3337,24 +3322,11 @@
         "node": ">= 16"
       }
     },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3367,6 +3339,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/comment-parser": {
@@ -3596,6 +3569,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -3849,15 +3823,6 @@
         "@esbuild/win32-arm64": "0.25.8",
         "@esbuild/win32-ia32": "0.25.8",
         "@esbuild/win32-x64": "0.25.8"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -4747,15 +4712,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5299,6 +5255,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6714,15 +6671,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7199,6 +7147,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7327,6 +7276,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8273,23 +8223,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
@@ -8309,48 +8242,12 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -8392,16 +8289,12 @@
       "name": "@pydantic/genai-prices",
       "version": "0.1.4",
       "license": "MIT",
-      "dependencies": {
-        "yargs": "^17.7.2"
-      },
       "bin": {
         "genai-prices": "dist/cli.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@types/node": "^22.17.0",
-        "@types/yargs": "^17.0.24",
         "@typescript-eslint/utils": "^8.26.1",
         "@vitest/coverage-v8": "^3.2.7",
         "@vitest/ui": "^3.2.4",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -58,13 +58,9 @@
     "knip": "knip",
     "test:coverage": "vitest run --coverage"
   },
-  "dependencies": {
-    "yargs": "^17.7.2"
-  },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@types/node": "^22.17.0",
-    "@types/yargs": "^17.0.24",
     "@typescript-eslint/utils": "^8.26.1",
     "@vitest/coverage-v8": "^3.2.7",
     "@vitest/ui": "^3.2.4",

--- a/packages/js/src/cli.ts
+++ b/packages/js/src/cli.ts
@@ -1,7 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-type-conversion */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import yargs from 'yargs'
-import { hideBin } from 'yargs/helpers'
+import { parseArgs } from 'node:util'
 
 import type { Provider } from './types'
 
@@ -9,64 +7,78 @@ import { version } from '../package.json'
 import { data as embeddedData } from './data'
 import { calcPrice } from './index'
 
-interface Argv {
-  $0: string
-  _: (number | string)[]
-  'auto-update'?: boolean
-  autoUpdate?: boolean
-  'cache-audio-read-tokens'?: number
-  'cache-read-tokens'?: number
-  'cache-write-tokens'?: number
-  'input-audio-tokens'?: number
-  'input-tokens'?: number
-  model?: string | string[]
-  'output-audio-tokens'?: number
-  'output-tokens'?: number
-  provider?: string
-  timestamp?: string
+const HELP = `genai-prices <command>
+
+Commands:
+  genai-prices list [provider]  List providers and models
+  genai-prices calc <model...>  Calculate price
+
+Options:
+  --input-tokens <number>
+  --cache-write-tokens <number>
+  --cache-read-tokens <number>
+  --output-tokens <number>
+  --input-audio-tokens <number>
+  --cache-audio-read-tokens <number>
+  --output-audio-tokens <number>
+  --provider <id>
+  --auto-update                 Enable auto-update from GitHub
+  --timestamp <RFC3339>
+  -v, --version                 Show version number
+  -h, --help                    Show help`
+
+const PARSE_ARGS_CONFIG = {
+  allowPositionals: true,
+  options: {
+    'auto-update': { type: 'boolean' },
+    'cache-audio-read-tokens': { type: 'string' },
+    'cache-read-tokens': { type: 'string' },
+    'cache-write-tokens': { type: 'string' },
+    help: { short: 'h', type: 'boolean' },
+    'input-audio-tokens': { type: 'string' },
+    'input-tokens': { type: 'string' },
+    'output-audio-tokens': { type: 'string' },
+    'output-tokens': { type: 'string' },
+    provider: { type: 'string' },
+    timestamp: { type: 'string' },
+    version: { short: 'v', type: 'boolean' },
+  },
+  strict: true,
+} as const
+
+function printHelp(): void {
+  console.log(HELP)
 }
 
-const argv = yargs(hideBin(process.argv))
-  .scriptName('genai-prices')
-  .command('list [provider]', 'List providers and models', (y) =>
-    y.positional('provider', { describe: 'Provider ID to filter', type: 'string' })
-  )
-  .command('calc <model...>', 'Calculate price', (y) =>
-    y
-      .positional('model', { array: true, describe: 'Model(s) (optionally provider:model)', type: 'string' })
-      .option('input-tokens', { type: 'number' })
-      .option('cache-write-tokens', { type: 'number' })
-      .option('cache-read-tokens', { type: 'number' })
-      .option('output-tokens', { type: 'number' })
-      .option('input-audio-tokens', { type: 'number' })
-      .option('cache-audio-read-tokens', { type: 'number' })
-      .option('output-audio-tokens', { type: 'number' })
-      .option('provider', { type: 'string' })
-      .option('auto-update', { default: false, type: 'boolean' })
-      .option('timestamp', { describe: 'RFC3339 timestamp', type: 'string' })
-  )
-  .option('auto-update', { describe: 'Enable auto-update from GitHub', type: 'boolean' })
-  .option('input-tokens', { type: 'number' })
-  .option('cache-write-tokens', { type: 'number' })
-  .option('cache-read-tokens', { type: 'number' })
-  .option('output-tokens', { type: 'number' })
-  .option('input-audio-tokens', { type: 'number' })
-  .option('cache-audio-read-tokens', { type: 'number' })
-  .option('output-audio-tokens', { type: 'number' })
-  .option('provider', { type: 'string' })
-  .option('timestamp', { describe: 'RFC3339 timestamp', type: 'string' })
-  .version(version)
-  .help()
-  .parseSync() as Argv
+function parseCliArgs(): ReturnType<typeof parseArgs<typeof PARSE_ARGS_CONFIG>> {
+  try {
+    return parseArgs(PARSE_ARGS_CONFIG)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    printHelp()
+    process.exit(1)
+  }
+}
 
-function main() {
-  // Handle list command
-  if (argv._[0] === 'list') {
+function main(): never {
+  const parsed = parseCliArgs()
+  const { positionals, values } = parsed
+  if (values.version) {
+    console.log(version)
+    process.exit(0)
+  }
+  if (values.help) {
+    printHelp()
+    process.exit(0)
+  }
+
+  if (positionals[0] === 'list') {
     const providers = embeddedData
-    if (argv.provider) {
-      const p = providers.find((p: Provider) => p.id === argv.provider)
+    const providerId = values.provider ?? positionals[1]
+    if (providerId) {
+      const p = providers.find((p: Provider) => p.id === providerId)
       if (!p) {
-        console.error(`Provider ${argv.provider} not found.`)
+        console.error(`Provider ${providerId} not found.`)
         process.exit(1)
       }
       console.log(`${p.name}: (${p.models.length} models)`)
@@ -84,26 +96,24 @@ function main() {
     process.exit(0)
   }
 
-  // Handle calc command or direct model names
-  const isCalcCommand = argv._[0] === 'calc'
-  const models = isCalcCommand ? (Array.isArray(argv.model) ? argv.model : [argv.model]) : argv._.filter((arg) => typeof arg === 'string')
+  const isCalcCommand = positionals[0] === 'calc'
+  const models = isCalcCommand ? positionals.slice(1) : positionals
 
   if (models.length > 0) {
     const usage = {
-      cache_audio_read_tokens: argv['cache-audio-read-tokens'] !== undefined ? Number(argv['cache-audio-read-tokens']) : undefined,
-      cache_read_tokens: argv['cache-read-tokens'] !== undefined ? Number(argv['cache-read-tokens']) : undefined,
-      cache_write_tokens: argv['cache-write-tokens'] !== undefined ? Number(argv['cache-write-tokens']) : undefined,
-      input_audio_tokens: argv['input-audio-tokens'] !== undefined ? Number(argv['input-audio-tokens']) : undefined,
-      input_tokens: argv['input-tokens'] !== undefined ? Number(argv['input-tokens']) : undefined,
-      output_audio_tokens: argv['output-audio-tokens'] !== undefined ? Number(argv['output-audio-tokens']) : undefined,
-      output_tokens: argv['output-tokens'] !== undefined ? Number(argv['output-tokens']) : undefined,
+      cache_audio_read_tokens: values['cache-audio-read-tokens'] === undefined ? undefined : Number(values['cache-audio-read-tokens']),
+      cache_read_tokens: values['cache-read-tokens'] === undefined ? undefined : Number(values['cache-read-tokens']),
+      cache_write_tokens: values['cache-write-tokens'] === undefined ? undefined : Number(values['cache-write-tokens']),
+      input_audio_tokens: values['input-audio-tokens'] === undefined ? undefined : Number(values['input-audio-tokens']),
+      input_tokens: values['input-tokens'] === undefined ? undefined : Number(values['input-tokens']),
+      output_audio_tokens: values['output-audio-tokens'] === undefined ? undefined : Number(values['output-audio-tokens']),
+      output_tokens: values['output-tokens'] === undefined ? undefined : Number(values['output-tokens']),
     }
-    const timestamp = argv.timestamp ? new Date(String(argv.timestamp)) : undefined
+    const timestamp = values.timestamp ? new Date(values.timestamp) : undefined
     let hadError = false
     for (const modelArg of models) {
       let providerId: string | undefined
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      let modelId = modelArg!
+      let modelId = modelArg
       if (modelId.includes(':')) {
         ;[providerId, modelId] = modelId.split(':', 2) as [string, string]
       }
@@ -140,8 +150,7 @@ function main() {
     process.exit(hadError ? 1 : 0)
   }
 
-  // If no command matched
-  yargs().showHelp()
+  printHelp()
   process.exit(1)
 }
 

--- a/packages/js/vite.config-cli.ts
+++ b/packages/js/vite.config-cli.ts
@@ -18,7 +18,7 @@ export default defineConfig({
       external: (id) => {
         // Externalize Node.js built-ins and node-fetch
         const nodeModules = [...builtinModules, ...builtinModules.map((m) => `node:${m}`)]
-        const externalModules = ['node-fetch', 'yargs']
+        const externalModules = ['node-fetch']
         return nodeModules.includes(id) || externalModules.includes(id)
       },
       output: {


### PR DESCRIPTION
Closes #138.

## Summary

- replace `yargs` with the built-in `node:util` argument parser
- preserve the existing list, calculation, help, and version CLI flows
- remove `yargs`, its type package, and its runtime dependency tree

## Verification

- `npm run ci`
- CLI smoke checks for help, version, calculation, direct model arguments, and invalid input

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I have reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

