### PR TITLE
Support mapping usage inputs

### DIFF
--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -218,9 +218,9 @@ class Usage:
             obj._reported_values()
             return obj
 
-        if isinstance(obj, dict):
+        if isinstance(obj, Mapping):
             raise TypeError(
-                'Dictionary usage inputs are not supported; pass a Usage instance or an object with attributes'
+                'Mapping usage inputs are not supported; pass a Usage instance or an object with attributes'
             )
 
         values: dict[str, UsageValue] = {}

--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -218,6 +218,11 @@ class Usage:
             obj._reported_values()
             return obj
 
+        if isinstance(obj, dict):
+            raise TypeError(
+                'Dictionary usage inputs are not supported; pass a Usage instance or an object with attributes'
+            )
+
         values: dict[str, UsageValue] = {}
         for key in _reported_usage_keys():
             value = _raw_usage_value(obj, key)

--- a/packages/python/genai_prices/types.py
+++ b/packages/python/genai_prices/types.py
@@ -218,11 +218,6 @@ class Usage:
             obj._reported_values()
             return obj
 
-        if isinstance(obj, Mapping):
-            raise TypeError(
-                'Mapping usage inputs are not supported; pass a Usage instance or an object with attributes'
-            )
-
         values: dict[str, UsageValue] = {}
         for key in _reported_usage_keys():
             value = _raw_usage_value(obj, key)
@@ -647,10 +642,13 @@ def _reported_usage_key_order() -> tuple[str, ...]:
 
 
 def _raw_usage_value(obj: object, key: str) -> UsageValue | None:
-    value = getattr(obj, key, None)
+    if _is_mapping(obj):
+        value = obj.get(key)
+    else:
+        value = getattr(obj, key, None)
     if value is None:
         return None
-    return cast(UsageValue, value)
+    return validate_usage_value(key, value)
 
 
 @dataclass

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import json
+from collections import UserDict
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from decimal import Decimal, localcontext
 from numbers import Integral
-from types import SimpleNamespace
+from types import MappingProxyType, SimpleNamespace
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -279,16 +280,22 @@ def test_usage_repr_orders_extra_registered_keys_by_registry_order() -> None:
         assert repr(usage) == 'Usage(input_tokens=3, sausage_tokens=1, cheese_tokens=2)'
 
 
-def test_usage_from_raw_rejects_dict() -> None:
-    with pytest.raises(TypeError, match='Dictionary usage inputs are not supported'):
-        Usage.from_raw({'input_tokens': 100, 'output_tokens': 50})
+@pytest.mark.parametrize(
+    'raw_usage',
+    [
+        {'input_tokens': 100, 'output_tokens': 50},
+        UserDict({'input_tokens': 100, 'output_tokens': 50}),
+        MappingProxyType({'input_tokens': 100, 'output_tokens': 50}),
+    ],
+)
+def test_mapping_usage_is_rejected(raw_usage: object) -> None:
+    with pytest.raises(TypeError, match='Mapping usage inputs are not supported'):
+        Usage.from_raw(raw_usage)
 
-
-def test_model_price_rejects_dict_usage() -> None:
     price = ModelPrice(input_mtok=Decimal('1'))
 
-    with pytest.raises(TypeError, match='Dictionary usage inputs are not supported'):
-        price.calc_price({'input_tokens': 1_000_000})
+    with pytest.raises(TypeError, match='Mapping usage inputs are not supported'):
+        price.calc_price(raw_usage)
 
 
 def test_usage_from_raw_reads_known_object_attributes() -> None:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
-from genai_prices.types import Usage
+from genai_prices.types import ModelPrice, Usage
 from genai_prices.units import UnitRegistry
 
 
@@ -279,10 +279,16 @@ def test_usage_repr_orders_extra_registered_keys_by_registry_order() -> None:
         assert repr(usage) == 'Usage(input_tokens=3, sausage_tokens=1, cheese_tokens=2)'
 
 
-def test_usage_from_raw_ignores_mapping_keys() -> None:
-    usage = Usage.from_raw({'input_tokens': 100, 'output_tokens': 50})
+def test_usage_from_raw_rejects_dict() -> None:
+    with pytest.raises(TypeError, match='Dictionary usage inputs are not supported'):
+        Usage.from_raw({'input_tokens': 100, 'output_tokens': 50})
 
-    assert usage == Usage()
+
+def test_model_price_rejects_dict_usage() -> None:
+    price = ModelPrice(input_mtok=Decimal('1'))
+
+    with pytest.raises(TypeError, match='Dictionary usage inputs are not supported'):
+        price.calc_price({'input_tokens': 1_000_000})
 
 
 def test_usage_from_raw_reads_known_object_attributes() -> None:

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -288,14 +288,18 @@ def test_usage_repr_orders_extra_registered_keys_by_registry_order() -> None:
         MappingProxyType({'input_tokens': 100, 'output_tokens': 50}),
     ],
 )
-def test_mapping_usage_is_rejected(raw_usage: object) -> None:
-    with pytest.raises(TypeError, match='Mapping usage inputs are not supported'):
-        Usage.from_raw(raw_usage)
+def test_usage_from_raw_reads_known_mapping_values(raw_usage: object) -> None:
+    usage = Usage.from_raw(raw_usage)
 
-    price = ModelPrice(input_mtok=Decimal('1'))
+    assert usage == Usage(input_tokens=100, output_tokens=50)
 
-    with pytest.raises(TypeError, match='Mapping usage inputs are not supported'):
-        price.calc_price(raw_usage)
+    price = ModelPrice(input_mtok=Decimal('1'), output_mtok=Decimal('2'))
+
+    assert price.calc_price(raw_usage) == {
+        'input_price': Decimal('0.0001'),
+        'output_price': Decimal('0.0001'),
+        'total_price': Decimal('0.0002'),
+    }
 
 
 def test_usage_from_raw_reads_known_object_attributes() -> None:


### PR DESCRIPTION
Closes #516.

## Summary

- Read registered usage values from mappings instead of silently pricing them at zero.
- Preserve attribute-based usage objects and `Usage` instances.
- Cover `dict`, `UserDict`, and `MappingProxyType` through both public entry points.
- Keep Python behavior aligned with JavaScript plain-object usage.

## Tests

- `make lint`
- `make typecheck`
- `make test`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.