### PR TITLE
Exclude generated JSON from Macroscope review

### DIFF
--- a/.macroscope/ignore.md
+++ b/.macroscope/ignore.md
@@ -1,0 +1,278 @@
+# Repository-specific generated JSON
+.github/aw/actions-lock.json
+prices/data.json
+prices/data_slim.json
+prices/data.schema.json
+prices/data_slim.schema.json
+prices/new_data/**/*.json
+prices/providers/.schema.json
+tests/dataset/usages.json
+
+# === Vendored / dependency directories ===
+**/.git/**
+**/__pycache__/**
+**/.pytest_cache/**
+**/.mypy_cache/**
+**/.ruff_cache/**
+**/venv/**
+**/.venv/**
+**/node_modules/**
+**/site-packages/**
+**/.pnpm-store/**
+**/__Snapshots__/**
+**/__snapshots__/**
+**/.agents/skills/**
+**/.claude/skills/**
+**/.github/skills/**
+**/bower_components/**
+**/jspm_packages/**
+**/.next/**
+**/.svelte-kit/**
+**/.nuxt/**
+**/.output/**
+**/.vercel/**
+**/.angular/**
+**/vendor/**
+**/_vendor/**
+**/third_party/**
+**/Pods/**
+**/.bundle/**
+
+# === Root-anchored ambiguous directories ===
+build/**
+out/**
+env/**
+ENV/**
+
+# === Generated / build-output directories (match anywhere) ===
+**/target/**
+**/dist/**
+**/generated/**
+**/intermediates/**
+**/generated_sources/**
+**/generated-sources/**
+**/generated-src/**
+**/src/main/generated/**
+
+# === Minified build output ===
+**/*.min.js
+**/*.min.css
+**/*.bundle.js
+
+# === Yarn PnP loader files ===
+**/.pnp.cjs
+**/.pnp.loader.mjs
+
+# === Generated protobuf / codegen files ===
+**/*_pb.d.ts
+**/*_pb.js
+**/*.pb.go
+**/*_pb2.py
+**/*_pb2_grpc.py
+**/*_pb2.pyi
+**/*.grpc.swift
+**/*.pb.swift
+**/*.sql.go
+**/*.designer.cs
+**/*.g.dart
+**/*.pb.dart
+**/*_pb.rb
+**/*.d.ts
+**/*.gen.ts
+**/*.gen.tsx
+**/*.gen.js
+**/*.gen.jsx
+
+# === Package manager files ===
+**/go.mod
+**/package.json
+**/*.pbxproj
+**/*.xcstrings
+**/*.strings
+**/*.properties
+**/pom.xml
+**/Package.swift
+**/bun.lock
+**/.eslintrc
+**/.eslintignore
+
+# === Lock / sum files ===
+**/go.sum
+**/package-lock.json
+**/pnpm-lock.yaml
+**/yarn.lock
+**/Package.resolved
+
+# === Images ===
+**/*.jpg
+**/*.jpeg
+**/*.png
+**/*.gif
+**/*.svg
+**/*.ico
+**/*.webp
+**/*.bmp
+**/*.tiff
+
+# === Fonts ===
+**/*.woff
+**/*.woff2
+**/*.ttf
+**/*.eot
+**/*.otf
+
+# === Media ===
+**/*.mp3
+**/*.mp4
+**/*.wav
+**/*.avi
+**/*.mov
+**/*.mkv
+**/*.flac
+**/*.ogg
+**/*.srt
+
+# === Archives ===
+**/*.zip
+**/*.tar
+**/*.gz
+**/*.rar
+**/*.7z
+**/*.bz2
+
+# === Documents ===
+**/*.pdf
+**/*.doc
+**/*.docx
+**/*.xls
+**/*.xlsx
+**/*.ppt
+**/*.pptx
+
+# === Data / serialized ===
+**/*.db
+**/*.sqlite
+**/*.sqlite3
+**/*.parquet
+**/*.avro
+**/*.arrow
+**/*.npy
+**/*.pkl
+**/*.jsonl
+
+# === ML models ===
+**/*.onnx
+**/*.tflite
+**/*.h5
+**/*.safetensors
+
+# === Compiled / binary ===
+**/*.exe
+**/*.dll
+**/*.so
+**/*.dylib
+**/*.bin
+**/*.pyc
+**/*.class
+**/*.o
+**/*.a
+**/*.wasm
+
+# === Certificates / keys ===
+**/*.cer
+**/*.pem
+**/*.p12
+
+# === Platform-specific / non-reviewable ===
+**/*.stringsdict
+**/*.snap
+**/*.adoc
+**/*.arb
+**/*.lock
+**/*.po
+**/*.fbx
+**/*.log
+**/*.xib
+**/*.meta
+**/*.kml
+**/*.prefab
+**/*.eml
+**/*.csv
+**/*.grpc.reflection
+**/*.js.map
+# === Go ===
+**/*_test.go
+
+# === TypeScript / JavaScript ===
+**/*.test.ts
+**/*.test.tsx
+**/*.test.js
+**/*.test.jsx
+**/*.test.mjs
+**/*.test.cjs
+**/*.test.mts
+**/*.test.cts
+**/*.spec.ts
+**/*.spec.tsx
+**/*.spec.js
+**/*.spec.jsx
+**/*.spec.mjs
+**/*.spec.cjs
+**/*.spec.mts
+**/*.spec.cts
+**/*.e2e.ts
+**/*.e2e.tsx
+**/*.e2e.js
+**/*.e2e.jsx
+**/*.e2e.mjs
+**/*.e2e.cjs
+**/*.integration.ts
+**/*.integration.tsx
+**/*.integration.js
+**/*.integration.jsx
+**/*.integration.mjs
+**/*.integration.cjs
+**/__tests__/**
+
+# === Python ===
+**/test_*.py
+**/*_test.py
+
+# === Java / Kotlin ===
+**/*Test.java
+**/*Tests.java
+**/*Spec.java
+**/*IT.java
+**/*ITCase.java
+**/*Test.kt
+**/*Tests.kt
+**/*Spec.kt
+**/*IT.kt
+**/*ITCase.kt
+**/src/test/java/**
+**/src/test/kotlin/**
+**/src/androidTest/**
+**/src/integrationTest/**
+
+# === Swift ===
+**/*Tests.swift
+**/*UITests.swift
+**/*Tests/**
+**/*UITests/**
+
+# === Rust ===
+**/tests/*.rs
+**/*_test.rs
+**/test_*.rs
+
+# === Ruby ===
+**/*_test.rb
+**/*_spec.rb
+**/test_*.rb
+
+# === Generic test directories ===
+**/test/**
+**/tests/**
+**/spec/**
+**/specs/**
+**/e2e/**

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,6 @@
 /.github/workflows/*.lock.yml
 /.github/workflows/agentics-maintenance.yml
 /.github/aw/
+
+# Plain glob patterns, not Markdown prose.
+/.macroscope/ignore.md


### PR DESCRIPTION
## Summary

- exclude generated and frozen pricing JSON artifacts from Macroscope review
- exclude the generated gh-aw action lock and usage corpus
- preserve Macroscope default ignore patterns
- prevent Prettier from rewriting the glob file

## Evidence

A recent pricing PR had Macroscope review both generated v2 payloads as two of its six code objects. The source YAML remains reviewable; build hooks continue to verify the generated output.

## Validation

- uv run prek run --files .macroscope/ignore.md .prettierignore
- verified the ignore file remains byte-identical after hooks
- compared the copied defaults with the current Macroscope documentation

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

