### PR TITLE
Exclude generated bundled package data from Macroscope review

### DIFF
--- a/.macroscope/ignore.md
+++ b/.macroscope/ignore.md
@@ -8,6 +8,12 @@ prices/new_data/**/*.json
 prices/providers/.schema.json
 tests/dataset/usages.json
 
+# Generated bundled package data (rewritten from prices/ by `make build`)
+packages/python/genai_prices/data.py
+packages/python/genai_prices/data_units.py
+packages/js/src/data.ts
+packages/js/src/dataUnits.ts
+
 # === Vendored / dependency directories ===
 **/.git/**
 **/__pycache__/**


### PR DESCRIPTION
Follow-up to #621: the four bundled data files (`packages/python/genai_prices/data.py`, `data_units.py`, `packages/js/src/data.ts`, `dataUnits.ts`) are regenerated by `make build` and were still being included in Macroscope reviews — e.g. they made up roughly a third of the reviewed diff on #637 after #621 landed. Only the provider YAML and `units.yml` need review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

