### PR TITLE
Schedule provider price refreshes

### DIFF
--- a/.github/workflows/update-prices.yml
+++ b/.github/workflows/update-prices.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Read importer targets
         id: targets
         run: |
-          targets=$(make --silent list-price-importers | jq --raw-input --slurp --compact-output 'split("\n") | map(select(length > 0))')
+          targets=$(make --silent list-provider-price-importers | jq --raw-input --slurp --compact-output 'split("\n") | map(select(length > 0))')
           echo "targets=$targets" >> "$GITHUB_OUTPUT"
 
   import:
@@ -64,7 +64,7 @@ jobs:
           set -e
 
           if [ "$status" -eq 0 ]; then
-            git add --all
+            git add --all -- . ':(exclude)price-update/**'
             git diff --cached --binary --full-index > price-update/changes.patch
             printf -- '- `%s`: succeeded\n' "$TARGET" > price-update/result.md
             echo "### $TARGET: succeeded" >> "$GITHUB_STEP_SUMMARY"
@@ -93,10 +93,10 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: importer-*
-          path: importer-results
+          path: ${{ runner.temp }}/importer-results
       - name: Apply successful importer changes
         run: |
-          find importer-results -name changes.patch -print0 | sort --zero-terminated | while IFS= read -r -d '' patch; do
+          find "$RUNNER_TEMP/importer-results" -name changes.patch -print0 | sort --zero-terminated | while IFS= read -r -d '' patch; do
             if [ -s "$patch" ]; then
               git apply --index "$patch"
             fi
@@ -116,10 +116,10 @@ jobs:
             printf 'Automated price refresh from [workflow run %s](%s/%s/actions/runs/%s).\n\n' \
               "$GITHUB_RUN_ID" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
             printf '## Importers\n\n'
-            find importer-results -name result.md -print0 | sort --zero-terminated | xargs --null cat
+            find "$RUNNER_TEMP/importer-results" -name result.md -print0 | sort --zero-terminated | xargs --null cat
             printf '\n## AI Disclaimer\n\n'
             printf "This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.\n"
-          } > price-update-pr-body.md
+          } > "$RUNNER_TEMP/price-update-pr-body.md"
       - name: Create GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -136,4 +136,4 @@ jobs:
           delete-branch: true
           commit-message: Refresh provider prices
           title: Refresh provider prices
-          body-path: price-update-pr-body.md
+          body-path: ${{ runner.temp }}/price-update-pr-body.md

--- a/.github/workflows/update-prices.yml
+++ b/.github/workflows/update-prices.yml
@@ -50,8 +50,6 @@ jobs:
         with:
           version: "0.12.1"
           enable-cache: true
-      - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
-        if: matrix.target == 'helicone-get'
       - run: uv sync --frozen --all-packages --all-extras
       - name: Run importer
         env:

--- a/.github/workflows/update-prices.yml
+++ b/.github/workflows/update-prices.yml
@@ -1,0 +1,139 @@
+name: Update prices
+
+# Requires a GitHub App with contents:write and pull_requests:write permissions.
+# Configure its id as PRICE_UPDATE_APP_ID and private key as PRICE_UPDATE_APP_PRIVATE_KEY.
+
+on:
+  schedule:
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-prices
+  cancel-in-progress: false
+
+env:
+  UV_FROZEN: "1"
+  UV_PYTHON: "3.13"
+
+jobs:
+  list-importers:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.targets.outputs.targets }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Read importer targets
+        id: targets
+        run: |
+          targets=$(make --silent list-price-importers | jq --raw-input --slurp --compact-output 'split("\n") | map(select(length > 0))')
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+
+  import:
+    name: Run ${{ matrix.target }}
+    needs: list-importers
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.list-importers.outputs.targets) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.12.1"
+          enable-cache: true
+      - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
+        if: matrix.target == 'helicone-get'
+      - run: uv sync --frozen --all-packages --all-extras
+      - name: Run importer
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          mkdir price-update
+          set +e
+          make "$TARGET" 2>&1 | tee price-update/importer.log
+          status=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$status" -eq 0 ]; then
+            git add --all
+            git diff --cached --binary --full-index > price-update/changes.patch
+            printf -- '- `%s`: succeeded\n' "$TARGET" > price-update/result.md
+            echo "### $TARGET: succeeded" >> "$GITHUB_STEP_SUMMARY"
+          else
+            : > price-update/changes.patch
+            printf -- '- `%s`: failed - [workflow run](%s/%s/actions/runs/%s)\n' \
+              "$TARGET" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" > price-update/result.md
+            echo "### $TARGET: failed" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Store importer result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: importer-${{ matrix.target }}
+          path: price-update
+          retention-days: 7
+
+  create-pull-request:
+    needs: import
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Download importer results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: importer-*
+          path: importer-results
+      - name: Apply successful importer changes
+        run: |
+          find importer-results -name changes.patch -print0 | sort --zero-terminated | while IFS= read -r -d '' patch; do
+            if [ -s "$patch" ]; then
+              git apply --index "$patch"
+            fi
+          done
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.12.1"
+          enable-cache: true
+      - run: uv sync --frozen --all-packages --all-extras
+      - name: Rebuild generated data
+        run: |
+          make build
+          uv run python tests/dataset/extract_usages.py
+      - name: Build pull request body
+        run: |
+          {
+            printf 'Automated price refresh from [workflow run %s](%s/%s/actions/runs/%s).\n\n' \
+              "$GITHUB_RUN_ID" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
+            printf '## Importers\n\n'
+            find importer-results -name result.md -print0 | sort --zero-terminated | xargs --null cat
+            printf '\n## AI Disclaimer\n\n'
+            printf "This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.\n"
+          } > price-update-pr-body.md
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.PRICE_UPDATE_APP_ID }}
+          private-key: ${{ secrets.PRICE_UPDATE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: automated/update-prices
+          delete-branch: true
+          commit-message: Refresh provider prices
+          title: Refresh provider prices
+          body-path: price-update-pr-body.md

--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,13 @@ ovhcloud-get: ## get ovhcloud ai endpoints prices
 quicksilverpro-get: ## get quicksilver pro prices
 	uv run -m prices get_quicksilverpro_prices
 
-PRICE_IMPORTERS := \
+SOURCE_PRICE_IMPORTERS := \
 	helicone-get \
 	openrouter-get \
 	litellm-get \
-	simonw-prices-get \
+	simonw-prices-get
+
+PROVIDER_PRICE_IMPORTERS := \
 	huggingface-get \
 	arcee-get \
 	cloudflare-get \
@@ -95,9 +97,15 @@ PRICE_IMPORTERS := \
 	ovhcloud-get \
 	quicksilverpro-get
 
+PRICE_IMPORTERS := $(SOURCE_PRICE_IMPORTERS) $(PROVIDER_PRICE_IMPORTERS)
+
 .PHONY: list-price-importers
 list-price-importers: ## list price importer targets
 	@printf '%s\n' $(PRICE_IMPORTERS)
+
+.PHONY: list-provider-price-importers
+list-provider-price-importers: ## list importers that update provider YAML
+	@printf '%s\n' $(PROVIDER_PRICE_IMPORTERS)
 
 .PHONY: get-all-prices
 get-all-prices: $(PRICE_IMPORTERS) ## get all prices

--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,24 @@ ovhcloud-get: ## get ovhcloud ai endpoints prices
 quicksilverpro-get: ## get quicksilver pro prices
 	uv run -m prices get_quicksilverpro_prices
 
+PRICE_IMPORTERS := \
+	helicone-get \
+	openrouter-get \
+	litellm-get \
+	simonw-prices-get \
+	huggingface-get \
+	arcee-get \
+	cloudflare-get \
+	cursor-get \
+	ovhcloud-get \
+	quicksilverpro-get
+
+.PHONY: list-price-importers
+list-price-importers: ## list price importer targets
+	@printf '%s\n' $(PRICE_IMPORTERS)
+
 .PHONY: get-all-prices
-get-all-prices: helicone-get openrouter-get litellm-get simonw-prices-get huggingface-get arcee-get cloudflare-get cursor-get ovhcloud-get quicksilverpro-get ## get all prices
+get-all-prices: $(PRICE_IMPORTERS) ## get all prices
 
 .PHONE: update-price-discrepancies
 update-price-discrepancies: ## update price discrepancies

--- a/prices/helicone_get/pull.sh
+++ b/prices/helicone_get/pull.sh
@@ -11,7 +11,7 @@ if [ -d "helicone-repo" ]; then
     git pull origin main
     cd ..
 else
-    git clone --branch main --single-branch --depth 1 git@github.com:Helicone/helicone.git helicone-repo
+    git clone --branch main --single-branch --depth 1 https://github.com/Helicone/helicone.git helicone-repo
 fi
 
 cp -r helicone-repo/packages/cost .


### PR DESCRIPTION
Schedule every importer weekly and on demand, isolate failures, combine successful patches, rebuild generated data, and create or update one rolling price PR. The workflow uses a GitHub App token so its PR triggers normal CI, and the importer write token is never available to the importer jobs.

This depends on [#635](https://github.com/pydantic/genai-prices/pull/635). Before merging, configure `PRICE_UPDATE_APP_ID` and `PRICE_UPDATE_APP_PRIVATE_KEY` for an installed GitHub App with `contents: write` and `pull_requests: write` permissions.

Closes #627. Verified with `make all`, all pre-commit hooks, `actionlint`, and `zizmor`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

