### PR TITLE
Fix npm release artifact packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
       - run: npm run build --workspace=packages/js
+      - run: mkdir -p npm-dist
       - run: npm pack --workspace=packages/js --pack-destination npm-dist
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
The v0.1.5 release build failed before either publish job because `npm pack --pack-destination npm-dist` does not create its destination directory on a fresh runner.

Create `npm-dist` before packing so the tarball can be uploaded to the npm publishing job.

The rest of the release build, including tag-derived versioning and both package builds, succeeded.

Validation:
- `uvx pre-commit run --files .github/workflows/ci.yml`
- reproduced `npm pack` failing with exit 254 when the destination is absent and succeeding with exit 0 after creating it

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

