### PR TITLE
Prevent silently skipped release publishers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,20 +212,29 @@ jobs:
       - run: npm run build --workspace=packages/js
       - run: mkdir -p npm-dist
       - run: npm pack --workspace=packages/js --pack-destination npm-dist
+      - name: Verify npm release artifact
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: test -f "npm-dist/pydantic-genai-prices-${VERSION}.tgz"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-pypi-dist
           path: dist/
+          if-no-files-found: error
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-npm-dist
           path: npm-dist/
+          if-no-files-found: error
 
   release-pypi:
     name: publish to PyPI
     needs: [release-build]
-    if: needs.release-build.result == 'success'
+    # Not success(): v2-schema-frozen is skipped on tag runs, and a skipped job anywhere in the
+    # needs chain makes success() false. Including a status function also prevents GitHub from
+    # implicitly wrapping this expression in success().
+    if: ${{ !cancelled() && needs.release-build.result == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: release-pypi
@@ -245,7 +254,8 @@ jobs:
   release-npm:
     name: publish to npm
     needs: [release-build]
-    if: needs.release-build.result == 'success'
+    # Keep this explicit status function in sync with release-pypi; see the comment above.
+    if: ${{ !cancelled() && needs.release-build.result == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: release-npm
@@ -266,3 +276,16 @@ jobs:
 
       # Trusted publishing (OIDC) - no token; npm attaches provenance automatically.
       - run: npm publish npm-dist/pydantic-genai-prices-*.tgz --access public
+
+  release-check:
+    name: check release published
+    needs: [release-pypi, release-npm]
+    # This status function ensures the job still runs and reports a failure if a publish job is
+    # skipped or fails. Without it, GitHub would silently skip this job too.
+    if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify both publish jobs succeeded
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,8 +4,10 @@ Keep it simple!
 
 1. Create a [GitHub release](https://github.com/pydantic/genai-prices/releases/new) with a new tag
    `vX.Y.Z` (plain semver, no pre-release suffix) and let GitHub generate the changelog
-2. That's it: the tag runs CI, and once it's green the `release-pypi` and `release-npm` jobs
-   publish `genai-prices` X.Y.Z to PyPI and `@pydantic/genai-prices` X.Y.Z to npm
+2. Wait for the tag's CI run to reach the `release-pypi` and `release-npm` jobs. In the run's
+   **Review deployments** prompt, select both protected environments and approve them
+3. Wait for `check release published` to pass, then confirm that `genai-prices` X.Y.Z is on PyPI
+   and `@pydantic/genai-prices` X.Y.Z is on npm
 
 Nothing in the repo holds the version. Python reads it from the tag at build time via
 `uv-dynamic-versioning` (commits between tags build as `X.Y.(Z+1).devN+g<sha>`), and the release job


### PR DESCRIPTION
The recreated v0.1.5 tag built valid artifacts, but both publish jobs were skipped while the workflow remained green. Their job-level conditions omitted an explicit status function, so GitHub implicitly applied `success()`, which is false because the tag run has the transitively skipped `v2-schema-frozen` job.

This PR:

- uses `!cancelled()` on both publisher conditions so successful release artifacts reach the protected publishing environments
- adds a terminal release gate that fails unless both registry jobs succeed
- makes missing uploaded artifacts an error and verifies the exact npm tarball
- documents the protected-environment approval and final registry checks

This follows the same skipped-needs fix already used by `release-build` after v0.0.70.

Checks: `uvx pre-commit run --files .github/workflows/ci.yml RELEASE.md`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/genai-prices/pull/661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

