### PR TITLE
Fix PyPI and npm release publishers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,9 +318,12 @@ jobs:
           name: release-pypi-dist
           path: dist/
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          skip-existing: true
+          version: "0.12.1"
+          enable-cache: false
+
+      - run: uv publish --trusted-publishing always --check-url https://pypi.org/simple/ dist/*
 
   release-npm:
     name: publish to npm
@@ -346,7 +349,7 @@ jobs:
           path: npm-dist/
 
       # Trusted publishing (OIDC) - no token; npm attaches provenance automatically.
-      - run: npm publish npm-dist/pydantic-genai-prices-*.tgz --access public
+      - run: npm publish ./npm-dist/pydantic-genai-prices-*.tgz --access public
 
   release-check:
     name: check release published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
           version: "0.12.1"
           enable-cache: false
 
-      - run: uv publish --trusted-publishing always --check-url https://pypi.org/simple/ dist/*
+      - run: uv publish --trusted-publishing always
 
   release-npm:
     name: publish to npm


### PR DESCRIPTION
The latest v0.1.5 release run reached both publish jobs, but each failed before uploading:

- the pinned `pypa/gh-action-pypi-publish` rejected the wheel's Metadata-Version 2.5
- npm parsed the unprefixed tarball path as a GitHub shorthand and attempted an SSH lookup

This restores the previously used uv trusted-publishing flow for PyPI and prefixes the npm tarball with `./` so npm treats it as a local package.

Validation:
- pre-commit (including YAML, Prettier, and zizmor)
- `uv 0.12.1 publish --dry-run --trusted-publishing never` against the exact failed v0.1.5 artifacts; uv discovered and accepted both `dist/*` files
- `npm publish --dry-run ./npm-dist/pydantic-genai-prices-*.tgz --access public` against the exact failed v0.1.5 artifact