### PR TITLE
test: validate extracted usage consistency

### DIFF
--- a/tests/dataset/extract_usages.py
+++ b/tests/dataset/extract_usages.py
@@ -50,7 +50,24 @@ registry = _get_registry()
 
 
 def get_direct_refinement_groups() -> dict[str, dict[str, tuple[str, ...]]]:
-    """Group mutually exclusive direct refinements by ancestor and added dimension."""
+    """Find groups of usage units that form partial partitions of an aggregate unit.
+
+    A unit is a descendant of another unit when its dimensions are a strict superset of the
+    ancestor's dimensions. A *direct refinement* adds exactly one dimension. For example,
+    ``output_reasoning_tokens`` and ``output_citation_tokens`` both directly refine
+    ``output_tokens`` by adding different values of the ``token_type`` dimension. Those values are
+    mutually exclusive, so their reported counts can be added and compared with the aggregate
+    output count.
+
+    The returned mapping is keyed first by the aggregate usage key and then by the dimension that
+    partitions it. Groups with only one registered value are omitted because the ordinary
+    descendant-versus-ancestor check already covers them.
+
+    Refinements that add different dimensions are deliberately kept in separate groups. For
+    example, ``cache_read_tokens`` adds ``token_type`` while ``input_audio_tokens`` adds
+    ``modality``; the same token can belong to both, so adding those counts would double-count their
+    overlap.
+    """
     result: dict[str, dict[str, tuple[str, ...]]] = {}
     for ancestor_key, ancestor in registry.units.items():
         groups: defaultdict[str, list[str]] = defaultdict(list)
@@ -70,7 +87,30 @@ direct_refinement_groups = get_direct_refinement_groups()
 
 
 def check_usage_consistency(usage_values: Mapping[str, UsageValue]) -> None:
-    """Check necessary containment constraints for positive extracted usage values."""
+    """Validate necessary containment constraints for one extractor's positive usage values.
+
+    ``extract_and_check`` removes zero values before calling this function, so every key here
+    represents usage the provider actually reported. The registry's dimensions define which units
+    contain other units. This function checks two consequences of that model:
+
+    1. Every reported descendant has all of its aggregate ancestors, and cannot be greater than any
+       of them. For example, positive ``output_reasoning_tokens`` requires ``output_tokens`` and
+       cannot exceed it.
+    2. Direct refinements with different values of the same dimension are mutually exclusive, so
+       their sum cannot exceed their aggregate. For example, reasoning and citation output tokens
+       cannot collectively exceed total output tokens.
+
+    These are necessary checks, not a proof that extraction matches every provider's accounting
+    semantics. In particular, values refined along different dimensions may overlap, and an absent
+    intersection is treated as unknown rather than zero. The check also cannot detect a
+    numerically plausible aggregate that omitted some usage; that needs provider-specific
+    reconciliation against fields such as ``total_tokens``. Keeping this validation in the real
+    response dataset catches impossible normalized usage without adding runtime validation for
+    caller-supplied ``Usage`` objects.
+
+    Raises:
+        AssertionError: If the extracted values violate a registry-defined containment constraint.
+    """
     for usage_key, value in usage_values.items():
         for ancestor_key in registry.ancestor_usage_keys(usage_key):
             ancestor_value = usage_values.get(ancestor_key)

--- a/tests/dataset/extract_usages.py
+++ b/tests/dataset/extract_usages.py
@@ -3,14 +3,18 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import json
+from collections import defaultdict
+from collections.abc import Mapping
 from itertools import combinations
 from typing import Any
 
 from utils import raw_bodies_path, this_dir
 
 from genai_prices import Usage, calc_price, extract_usage
+from genai_prices._usage import UsageValue, sum_usage_values
 from genai_prices.data_snapshot import get_snapshot
 from genai_prices.types import Provider, UsageExtractor
+from genai_prices.units import _get_registry
 
 
 @dataclasses.dataclass
@@ -18,7 +22,7 @@ class Case:
     provider_id: str
     api_flavor: str
     model_ref: str | None
-    usage_dict: dict[str, Any]
+    usage_dict: dict[str, UsageValue]
 
 
 extractors = [
@@ -40,6 +44,56 @@ def get_body_keys(extractor: UsageExtractor) -> set[str]:
 body_keys = set[str]().union(*[get_body_keys(extractor) for _, extractor in extractors])
 assert 'file' not in body_keys
 body_keys.add('file')
+
+
+registry = _get_registry()
+
+
+def get_direct_refinement_groups() -> dict[str, dict[str, tuple[str, ...]]]:
+    """Group mutually exclusive direct refinements by ancestor and added dimension."""
+    result: dict[str, dict[str, tuple[str, ...]]] = {}
+    for ancestor_key, ancestor in registry.units.items():
+        groups: defaultdict[str, list[str]] = defaultdict(list)
+        for descendant_key, descendant in registry.units.items():
+            added_dimensions = descendant.dimensions.items() - ancestor.dimensions.items()
+            if ancestor.dimensions.items() < descendant.dimensions.items() and len(added_dimensions) == 1:
+                dimension, _ = next(iter(added_dimensions))
+                groups[dimension].append(descendant_key)
+
+        multi_value_groups = {dimension: tuple(keys) for dimension, keys in groups.items() if len(keys) > 1}
+        if multi_value_groups:
+            result[ancestor_key] = multi_value_groups
+    return result
+
+
+direct_refinement_groups = get_direct_refinement_groups()
+
+
+def check_usage_consistency(usage_values: Mapping[str, UsageValue]) -> None:
+    """Check necessary containment constraints for positive extracted usage values."""
+    for usage_key, value in usage_values.items():
+        for ancestor_key in registry.ancestor_usage_keys(usage_key):
+            ancestor_value = usage_values.get(ancestor_key)
+            if ancestor_value is None:
+                raise AssertionError(f'{usage_key} ({value}) is missing aggregate {ancestor_key}')
+            if value > ancestor_value:
+                raise AssertionError(f'{usage_key} ({value}) cannot exceed {ancestor_key} ({ancestor_value})')
+
+    for aggregate_key, groups in direct_refinement_groups.items():
+        aggregate_value = usage_values.get(aggregate_key)
+        if aggregate_value is None:
+            continue
+        for dimension, refinement_keys in groups.items():
+            refinements = [(key, usage_values[key]) for key in refinement_keys if key in usage_values]
+            if len(refinements) < 2:
+                continue
+            refinement_total = sum_usage_values(value for _, value in refinements)
+            if refinement_total > aggregate_value:
+                details = ', '.join(f'{key} ({value})' for key, value in refinements)
+                raise AssertionError(
+                    f'mutually exclusive {dimension} usage {details} totals {refinement_total}, '
+                    f'which exceeds {aggregate_key} ({aggregate_value})'
+                )
 
 
 def rebuild_usages() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -171,7 +225,12 @@ def extract_and_check(body: dict[str, Any], extractor: UsageExtractor, provider:
         extracted = extract_usage(body, provider_id=provider.id, api_flavor=flavor)
         assert extracted.model and extracted.model.is_match(model_ref)
         assert usage == extracted.usage
-    usage_dict = {k: v for k, v in usage.__dict__.items() if v}
+    usage_dict: dict[str, UsageValue] = {k: v for k, v in usage.__dict__.items() if v}
+    try:
+        check_usage_consistency(usage_dict)
+    except AssertionError as exc:
+        source = body.get('file', '<unknown response>')
+        raise AssertionError(f'Inconsistent extracted usage for {provider.id}/{flavor} in {source}: {exc}') from exc
     return Case(provider.id, flavor, model_ref, usage_dict)
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
+
+from genai_prices.types import Provider, UsageExtractor, UsageExtractorMapping
 
 DATASET_DIR = Path(__file__).parent / 'dataset'
 
@@ -35,6 +38,84 @@ def test_usages_dataset_is_up_to_date(extract_usages_module: object) -> None:
         'usages.json is stale. Run `python tests/dataset/extract_usages.py` to regenerate it, check the '
         'diff, and commit it - the JS suite asserts against this file.'
     )
+
+
+def test_rebuild_usages_falls_back_to_current_dataset(
+    extract_usages_module: object, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    extract_usages = cast(Any, extract_usages_module)
+    (tmp_path / 'usages.json').write_text('[]')
+    monkeypatch.setattr(extract_usages, 'this_dir', tmp_path)
+    monkeypatch.setattr(extract_usages, 'raw_bodies_path', tmp_path / 'missing-raw-bodies.json')
+
+    assert extract_usages.rebuild_usages() == ([], [])
+
+
+def test_usage_consistency_accepts_contained_and_overlapping_details(extract_usages_module: object) -> None:
+    extract_usages = cast(Any, extract_usages_module)
+
+    extract_usages.check_usage_consistency(
+        {
+            'input_tokens': 10,
+            'input_text_tokens': 6,
+            'input_audio_tokens': 4,
+            'cache_read_tokens': 7,
+            'cache_audio_read_tokens': 4,
+        }
+    )
+
+
+def test_usage_consistency_rejects_missing_aggregate(extract_usages_module: object) -> None:
+    extract_usages = cast(Any, extract_usages_module)
+
+    with pytest.raises(AssertionError, match=r'output_reasoning_tokens \(6\) is missing aggregate output_tokens'):
+        extract_usages.check_usage_consistency({'output_reasoning_tokens': 6})
+
+
+def test_usage_consistency_rejects_descendant_greater_than_aggregate(extract_usages_module: object) -> None:
+    extract_usages = cast(Any, extract_usages_module)
+
+    with pytest.raises(
+        AssertionError,
+        match=r'output_reasoning_tokens \(6\) cannot exceed output_tokens \(5\)',
+    ):
+        extract_usages.check_usage_consistency({'output_tokens': 5, 'output_reasoning_tokens': 6})
+
+
+def test_usage_consistency_rejects_mutually_exclusive_details_over_aggregate(
+    extract_usages_module: object,
+) -> None:
+    extract_usages = cast(Any, extract_usages_module)
+
+    with pytest.raises(
+        AssertionError,
+        match=r'mutually exclusive token_type usage .* totals 11, which exceeds output_tokens \(10\)',
+    ):
+        extract_usages.check_usage_consistency(
+            {'output_tokens': 10, 'output_reasoning_tokens': 6, 'output_citation_tokens': 5}
+        )
+
+
+def test_extract_and_check_reports_inconsistent_usage_context(extract_usages_module: object) -> None:
+    extract_usages = cast(Any, extract_usages_module)
+    extractor = UsageExtractor(
+        root='usage',
+        mappings=[
+            UsageExtractorMapping(path='output_tokens', dest='output_tokens'),
+            UsageExtractorMapping(path='reasoning_tokens', dest='output_reasoning_tokens'),
+        ],
+    )
+    provider = Provider(name='Test', id='test', api_pattern='test', extractors=[extractor])
+    body = {'file': 'recorded-response.yaml', 'usage': {'output_tokens': 5, 'reasoning_tokens': 6}}
+
+    with pytest.raises(
+        AssertionError,
+        match=(
+            r'Inconsistent extracted usage for test/default in recorded-response.yaml: '
+            r'output_reasoning_tokens \(6\) cannot exceed output_tokens \(5\)'
+        ),
+    ):
+        extract_usages.extract_and_check(body, extractor, provider)
 
 
 def test_main_reports_current_dataset(


### PR DESCRIPTION
## Summary

- validate every extracted dataset usage independently of model pricing
- require positive detailed units to include and not exceed their registry-defined aggregates
- reject mutually exclusive direct refinements whose sum exceeds their aggregate
- include provider, API flavor, and cassette context in failures

This intentionally leaves provider-specific total-token reconciliation, authoritative cassette provenance, and cassette collector changes for separate work.

## Verification

- `make typecheck testcov test-js test-go`
- Python: 1,526 passed, 39 xfailed, 100% coverage
- JavaScript: 2,012 passed, 1 skipped
- Go: passed with race detection

`make all` could not run the Go linter locally because the installed Go 1.23 toolchain is older than the linter's Go 1.25 requirement; the remaining checks above passed independently.
